### PR TITLE
Implement field.types argument in dbWriteTable.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RPostgres
-Version: 0.1
+Version: 0.1.1
 Title: Experimental Rcpp Interface to PostgreSQL.
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),

--- a/R/tables.R
+++ b/R/tables.R
@@ -59,8 +59,13 @@ setMethod("dbWriteTable", c("PqConnection", "character", "data.frame"),
     }
 
     if (!found || overwrite) {
-      sql <- sqlCreateTable(conn, name, value, row.names = row.names,
-        temporary = temporary)
+      if (!missing(field.types)) {
+        types <- structure(field.types, .Names = colnames(value))
+      } else {
+        types <- value
+      }
+      sql <- sqlCreateTable(conn, name, types, row.names = row.names,
+                            temporary = temporary)
       dbGetQuery(conn, sql)
     }
 

--- a/tests/testthat/helper-with_database_connection.R
+++ b/tests/testthat/helper-with_database_connection.R
@@ -1,0 +1,11 @@
+#' Execute an R expression with access to a database connection.
+#'
+#' @param expr expression. Any R expression.
+#' @param con PqConnection. A database connection, by default.
+#'    \code{dbConnect(RPostgres::Postgres())}.
+#' @return the return value of the evaluated \code{expr}.
+with_database_connection <- function(expr, con = dbConnect(RPostgres::Postgres())) {
+  context <- list2env(list(con = con), parent = parent.frame())
+  eval(substitute(expr), envir = context)
+}
+

--- a/tests/testthat/helper-with_table.R
+++ b/tests/testthat/helper-with_table.R
@@ -1,0 +1,11 @@
+#' Run an expression that creates and touches a table, then clean up.
+#'
+#' @param con PqConnection. The database connection.
+#' @param tbl character. The table name.
+#' @param expr expression. The R expression to execute.
+#' @return the return value of the \code{expr}.
+with_table <- function(con, tbl, expr) {
+  on.exit(dbRemoveTable(con, tbl), add = TRUE)
+  force(expr)
+}
+

--- a/tests/testthat/helper-without_rownames.R
+++ b/tests/testthat/helper-without_rownames.R
@@ -1,0 +1,5 @@
+without_rownames <- function(df) {
+  row.names(df) <- NULL
+  df
+}
+

--- a/tests/testthat/test-dbGetQuery.R
+++ b/tests/testthat/test-dbGetQuery.R
@@ -1,6 +1,6 @@
 context("dbGetQuery")
 
-test_that("special charaters work", {
+test_that("special characters work", {
   angstrom <- enc2utf8("\\u00e5")
   con <- dbConnect(RPostgres::Postgres())
 

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -1,0 +1,87 @@
+context("dbWriteTable")
+
+with_database_connection({
+  describe("Writing to the database", {
+    test_that("writing to a database table is successful", {
+      with_table(con, "beaver2", {
+        dbWriteTable(con, "beaver2", beaver2)
+        expect_equal(dbReadTable(con, "beaver2"), beaver2)
+      })
+    })
+
+    test_that("writing to a database table with character features is successful", {
+      with_table(con, "iris", {
+        iris2 <- transform(iris, Species = as.character(Species))
+        dbWriteTable(con, "iris", iris2)
+        expect_equal(dbReadTable(con, "iris"), iris2)
+      })
+    })
+  })
+
+  describe("Appending to the database", {
+    test_that("append to a database table is successful", {
+      with_table(con, "beaver2", {
+        dbWriteTable(con, "beaver2", beaver2)
+        dbWriteTable(con, "beaver2", beaver2, append = TRUE)
+        expect_equal(dbReadTable(con, "beaver2"), rbind(beaver2, beaver2))
+      })
+    })
+
+    test_that("append to a database table with character features is successful", {
+      with_table(con, "iris", {
+        iris2 <- transform(iris, Species = as.character(Species))
+        dbWriteTable(con, "iris", iris2)
+        dbWriteTable(con, "iris", iris2, append = TRUE)
+        expect_equal(dbReadTable(con, "iris"), rbind(iris2, iris2))
+      })
+    })
+  })
+
+  describe("Usage of the field.types argument", {
+    test_that("New table creation respects the field.types argument", {
+      with_table(con, "iris", {
+        iris2       <- transform(iris, Petal.Width = as.integer(Petal.Width),
+                                 Species = as.character(Species))
+        field.types <- c("real", "double precision", "numeric", "bigint", "text")
+
+        dbWriteTable(con, "iris", iris2, field.types = field.types)
+        expect_equal(dbReadTable(con, "iris"), iris2)
+
+        # http://stackoverflow.com/questions/2146705/select-datatype-of-the-field-in-postgres
+        types <- DBI::dbGetQuery(con,
+          paste("select column_name, data_type from information_schema.columns ",
+                "where table_name = 'iris'"))
+        expected <- data.frame(column_name = colnames(iris2),
+                               data_type = field.types, stringsAsFactors = FALSE)
+        types    <- without_rownames(types[order(types$column_name), ])
+        expected <- without_rownames(expected[order(expected$column_name), ])
+
+        expect_equal(types, expected)
+      })
+    })
+
+    test_that("Appending still works when using the field.types argument", {
+      with_table(con, "iris", {
+        iris2       <- transform(iris, Petal.Width = as.integer(Petal.Width),
+                                 Species = as.character(Species))
+        field.types <- c("real", "double precision", "numeric", "bigint", "text")
+
+        dbWriteTable(con, "iris", iris2, field.types = field.types)
+        dbWriteTable(con, "iris", iris2, field.types = field.types, append = TRUE)
+        expect_equal(dbReadTable(con, "iris"), rbind(iris2, iris2))
+
+        # http://stackoverflow.com/questions/2146705/select-datatype-of-the-field-in-postgres
+        types <- DBI::dbGetQuery(con,
+          paste("select column_name, data_type from information_schema.columns ",
+                "where table_name = 'iris'"))
+        expected <- data.frame(column_name = colnames(iris2),
+                               data_type = field.types, stringsAsFactors = FALSE)
+        types    <- without_rownames(types[order(types$column_name), ])
+        expected <- without_rownames(expected[order(expected$column_name), ])
+
+        expect_equal(types, expected)
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
@hadley This is a pretty severe issue that clobbered our local cache database.

Consider the following.

``` r
iris2 <- iris[1:4, 1:4]
colnames(iris2) <- chartr(".", "_", colnames(iris2))
DBI::dbWriteTable(con, "fubar", iris2) # Where con uses the RPostgres adapter
```

Since the `field.types` argument in the `dbWriteTable` method is completely unused, this creates a table with auto-inferred `real` columns.

```
      Table "public.fubar"
    Column    | Type | Modifiers
--------------+------+-----------
 Sepal_Length | real |
 Sepal_Width  | real |
 Petal_Length | real |
 Petal_Width  | real |
```

Since we deal with IDs well north of 10,000,000 in our production database, this led to a truncation wherein IDs like 35,538,288 were truncated to 35,538,200 due to precision issues. The fix would be

``` r
DBI::dbWriteTable(con, "fubar", iris2, field.types = rep("double precision", 4))
```

except that this argument is currently not implemented by RPostgres.

I attempt to fix the issue by pre-creating a table with the correct types, as is demanded by `sqlCreateTable` when using a named character vector as the third argument. This solved our issues, and as it was a critical fix to our caching layer, I have taken the liberty of incrementing the R version. Let me know if you would like to see any further changes or remove the version update.
