### PR TITLE
DateTime parsing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Depends:
 Imports:
     methods,
     Rcpp (>= 0.11.4.2),
-    DBI (>= 0.3.1.9008)
+    DBI (>= 0.3.1.9008),
+    hms
 Suggests:
     testthat,
     DBItest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,5 @@ Collate:
     'result.R'
     'tables.R'
     'transactions.R'
+    'zzz.R'
 RoxygenNote: 6.0.1

--- a/R/connection.R
+++ b/R/connection.R
@@ -104,7 +104,7 @@ setMethod("dbDataType", "PqConnection", function(dbObj, obj) {
 
 get_data_type <- function(obj) {
   if (is.factor(obj)) return("TEXT")
-  if (inherits(obj, "POSIXt")) return("TIMESTAMP")
+  if (inherits(obj, "POSIXt")) return("TIMESTAMPTZ")
   if (inherits(obj, "Date")) return("DATE")
   if (inherits(obj, "hms")) return("TIME")
   switch(typeof(obj),

--- a/R/connection.R
+++ b/R/connection.R
@@ -104,7 +104,9 @@ setMethod("dbDataType", "PqConnection", function(dbObj, obj) {
 
 get_data_type <- function(obj) {
   if (is.factor(obj)) return("TEXT")
-
+  if (inherits(obj, "POSIXt")) return("TIMESTAMP")
+  if (inherits(obj, "Date")) return("DATE")
+  if (inherits(obj, "hms")) return("TIME")
   switch(typeof(obj),
     integer = "INTEGER",
     double = "REAL",

--- a/R/connection.R
+++ b/R/connection.R
@@ -106,7 +106,7 @@ get_data_type <- function(obj) {
   if (is.factor(obj)) return("TEXT")
   if (inherits(obj, "POSIXt")) return("TIMESTAMPTZ")
   if (inherits(obj, "Date")) return("DATE")
-  if (inherits(obj, "hms")) return("TIME")
+  if (inherits(obj, "difftime")) return("TIME")
   switch(typeof(obj),
     integer = "INTEGER",
     double = "REAL",

--- a/R/result.R
+++ b/R/result.R
@@ -107,7 +107,7 @@ setMethod("dbFetch", "PqResult", function(res, n = -1, ..., row.names = FALSE) {
 #' @rdname postgres-query
 #' @export
 setMethod("dbBind", "PqResult", function(res, params, ...) {
-  params <- lapply(params, as.character)
+  params <- lapply(params, as.character, usetz = TRUE)
   result_bind_params(res@ptr, params)
   invisible(res)
 })

--- a/R/tables.R
+++ b/R/tables.R
@@ -93,7 +93,9 @@ setMethod("sqlData", "PqConnection", function(con, value, row.names = NA, copy =
 
   # C code takes care of atomic vectors, just need to coerce objects
   is_object <- vapply(value, is.object, logical(1))
-  value[is_object] <- lapply(value[is_object], as.character)
+  is_posix <- vapply(value, function(c) inherits(c, "POSIXt"), logical(1))
+  value[is_posix] <- lapply(value[is_posix], function(col) format(col, usetz=T))
+  value[xor(is_object, is_posix)] <- lapply(value[is_object], as.character)
 
   value
 })

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,8 @@
+.onLoad <- function(libname, pkgname) {
+    options(digits.secs=6)
+    invisible()
+}
+
+.onUnload <- function(libname) {
+    options(digits.secs=NULL)
+}

--- a/man/postgres-tables.Rd
+++ b/man/postgres-tables.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/tables.R
 \docType{methods}
 \name{postgres-tables}
-\alias{postgres-tables}
-\alias{dbWriteTable,PqConnection,character,data.frame-method}
-\alias{sqlData,PqConnection-method}
-\alias{dbReadTable,PqConnection,character-method}
-\alias{dbListTables,PqConnection-method}
 \alias{dbExistsTable,PqConnection,character-method}
+\alias{dbListTables,PqConnection-method}
+\alias{dbReadTable,PqConnection,character-method}
 \alias{dbRemoveTable,PqConnection,character-method}
+\alias{dbWriteTable,PqConnection,character,data.frame-method}
+\alias{postgres-tables}
+\alias{sqlData,PqConnection-method}
 \title{Convenience functions for reading/writing DBMS tables}
 \usage{
 \S4method{dbWriteTable}{PqConnection,character,data.frame}(conn, name, value,
@@ -91,3 +91,4 @@ dbReadTable(con, "mtcars2")
 
 dbDisconnect(con)
 }
+

--- a/src/PqConnection.h
+++ b/src/PqConnection.h
@@ -6,6 +6,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include "PqUtils.h"
+#include <cstdlib>
 
 class PqResult;
 
@@ -31,7 +32,7 @@ public:
     }
     c_keys[n] = NULL;
     c_values[n] = NULL;
-
+    setenv("PGTZ", "UTC", 1);
     pConn_ = PQconnectdbParams(&c_keys[0], &c_values[0], false);
 
     if (PQstatus(pConn_) != CONNECTION_OK) {

--- a/src/PqResult.h
+++ b/src/PqResult.h
@@ -68,9 +68,10 @@ public:
 
   ~PqResult() {
     try {
-      if (active())
+      if (active()) {
         PQclear(pSpec_);
         pConn_->setCurrentResult(NULL);
+      }
     } catch (...) {}
   }
 
@@ -195,7 +196,24 @@ public:
     if (i < n) {
       out = dfResize(out, i);
     }
-
+    for(int i = 0; i < out.size(); i++){
+      Rcpp::RObject col = out[i];
+      switch (types_[i]) {
+      case PGDate:
+        col.attr("class") = Rcpp::CharacterVector::create("Date");
+        break;
+      case PGDatetime:
+      case PGDatetimeTZ:
+        col.attr("class") = Rcpp::CharacterVector::create("POSIXct", "POSIXt");
+        break;
+      case PGTime:
+        col.attr("class") = Rcpp::CharacterVector::create("hms", "difftime");
+        col.attr("units") = Rcpp::CharacterVector::create("secs");
+        break;
+      default:
+        break;
+      }
+    }
     return out;
   }
 
@@ -227,6 +245,9 @@ public:
       case PGReal: types[i] = "double"; break;
       case PGVector:  types[i] = "list"; break;
       case PGLogical:  types[i] = "logical"; break;
+      case PGDate: types[i] = "Date"; break;
+      case PGDatetime: types[i] = "POSIXct"; break;
+      case PGDatetimeTZ: types[i] = "POSIXct"; break;
       default: Rcpp::stop("Unknown variable type");
       }
     }
@@ -279,12 +300,22 @@ private:
       case 114: // JSON
       case 1042: // CHAR
       case 1043: // VARCHAR
+        types.push_back(PGString);
+        break;
       case 1082: // DATE
+        types.push_back(PGDate);
+        break;
       case 1083: // TIME
-      case 1114: // TIMESTAMP
-      case 1184: // TIMESTAMPTZOID
-      case 1186: // INTERVAL
       case 1266: // TIMETZOID
+        types.push_back(PGTime);
+        break;
+      case 1114: // TIMESTAMP
+        types.push_back(PGDatetime);
+        break;
+      case 1184: // TIMESTAMPTZOID
+        types.push_back(PGDatetimeTZ);
+        break;
+      case 1186: // INTERVAL
       case 3802: // JSONB
       case 2950: // UUID
         types.push_back(PGString);

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -106,7 +106,7 @@ public:
     }
     char* val = PQgetvalue(pRes_, 0, j);
     struct tm date = { 0 };
-    date.tm_sec = date.tm_min = date.tm_hour = date.tm_isdst = 0;
+    date.tm_isdst = -1;
     date.tm_year = (*val - 0x30)*1000 + (*(++val)-0x30)*100 +
       (*(++val)-0x30)*10 + (*(++val)-0x30) - 1900;
     val++;
@@ -123,7 +123,7 @@ public:
     char* val = PQgetvalue(pRes_, 0, j);
     char* end;
     struct tm date;
-    date.tm_isdst = 0;
+    date.tm_isdst = -1;
     date.tm_year = (*val - 0x30)*1000 + (*(++val)-0x30)*100 +
       (*(++val)-0x30)*10 + (*(++val)-0x30) - 1900;
     val++;

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -121,6 +121,7 @@ public:
       return NA_REAL;
     }
     char* val = PQgetvalue(pRes_, 0, j);
+    char* end;
     struct tm date;
     date.tm_isdst = 0;
     date.tm_year = (*val - 0x30)*1000 + (*(++val)-0x30)*100 +
@@ -134,8 +135,9 @@ public:
     val++;
     date.tm_min = (*(++val)-0x30)*10 + (*(++val)-0x30);
     val++;
-    date.tm_sec = (*(++val)-0x30)*10 + (*(++val)-0x30);
-    return mktime(&date);
+    double sec = strtod(++val, &end);
+    date.tm_sec = sec;
+    return mktime(&date) + (sec - date.tm_sec);
   }
 
   double valueTime(int j) {
@@ -147,8 +149,8 @@ public:
     val++;
     int min = (*(++val)-0x30)*10 + (*(++val)-0x30);
     val++;
-    int sec = (*(++val)-0x30)*10 + (*(++val)-0x30);
-    return static_cast<double>(hour * 3600 + min * 60 + sec);
+    double sec = strtod(++val, NULL);
+    return static_cast<double>(hour * 3600 + min * 60) + sec;
   }
 
   int valueLogical(int j) {

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -113,7 +113,7 @@ public:
     date.tm_mon = (*(++val)-0x30)*10 + (*(++val)-0x30) -1;
     val++;
     date.tm_mday = (*(++val)-0x30)*10 + (*(++val)-0x30);
-    return mktime(&date)/(24*60*60);
+    return timegm(&date)/(24*60*60);
   }
 
   double valueDatetime(int j) {
@@ -137,7 +137,7 @@ public:
     val++;
     double sec = strtod(++val, &end);
     date.tm_sec = sec;
-    return mktime(&date) + (sec - date.tm_sec);
+    return timegm(&date) + (sec - date.tm_sec);
   }
 
   double valueTime(int j) {

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -107,12 +107,19 @@ public:
     char* val = PQgetvalue(pRes_, 0, j);
     struct tm date = { 0 };
     date.tm_isdst = -1;
-    date.tm_year = (*val - 0x30)*1000 + (*(++val)-0x30)*100 +
-      (*(++val)-0x30)*10 + (*(++val)-0x30) - 1900;
+    date.tm_year = *val - 0x30;
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30);
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30);
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30) - 1900;
     val++;
-    date.tm_mon = (*(++val)-0x30)*10 + (*(++val)-0x30) -1;
+    date.tm_mon = 10 *(*(++val)-0x30);
+    date.tm_mon += (*(++val)-0x30) -1;
     val++;
-    date.tm_mday = (*(++val)-0x30)*10 + (*(++val)-0x30);
+    date.tm_mday = (*(++val)-0x30) * 10;
+    date.tm_mday += (*(++val)-0x30);
     return timegm(&date)/(24*60*60);
   }
 
@@ -124,16 +131,25 @@ public:
     char* end;
     struct tm date;
     date.tm_isdst = -1;
-    date.tm_year = (*val - 0x30)*1000 + (*(++val)-0x30)*100 +
-      (*(++val)-0x30)*10 + (*(++val)-0x30) - 1900;
+    date.tm_year = *val - 0x30;
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30);
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30);
+    date.tm_year *= 10;
+    date.tm_year += (*(++val)-0x30) - 1900;
     val++;
-    date.tm_mon = (*(++val)-0x30)*10 + (*(++val)-0x30)-1;
+    date.tm_mon = (*(++val)-0x30)*10;
+    date.tm_mon += (*(++val)-0x30)-1;
     val++;
-    date.tm_mday = (*(++val)-0x30)*10 + (*(++val)-0x30);
+    date.tm_mday = (*(++val)-0x30)*10;
+    date.tm_mday += (*(++val)-0x30);
     val++;
-    date.tm_hour = (*(++val)-0x30)*10 + (*(++val)-0x30);
+    date.tm_hour = (*(++val)-0x30)*10;
+    date.tm_hour += (*(++val)-0x30);
     val++;
-    date.tm_min = (*(++val)-0x30)*10 + (*(++val)-0x30);
+    date.tm_min = (*(++val)-0x30)*10;
+    date.tm_min += (*(++val)-0x30);
     val++;
     double sec = strtod(++val, &end);
     date.tm_sec = sec;
@@ -149,9 +165,11 @@ public:
       return NA_REAL;
     }
     char* val = PQgetvalue(pRes_, 0, j);
-    int hour = (*val-0x30)*10 + (*(++val)-0x30);
+    int hour = (*val-0x30)*10;
+    hour += (*(++val)-0x30);
     val++;
-    int min = (*(++val)-0x30)*10 + (*(++val)-0x30);
+    int min = (*(++val)-0x30)*10;
+    min += (*(++val)-0x30);
     val++;
     double sec = strtod(++val, NULL);
     return static_cast<double>(hour * 3600 + min * 60) + sec;

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -116,7 +116,7 @@ public:
     return timegm(&date)/(24*60*60);
   }
 
-  double valueDatetime(int j) {
+  double valueDatetime(int j, bool use_local = true) {
     if (valueNull(j)) {
       return NA_REAL;
     }
@@ -137,7 +137,11 @@ public:
     val++;
     double sec = strtod(++val, &end);
     date.tm_sec = sec;
-    return timegm(&date) + (sec - date.tm_sec);
+    if (use_local) {
+      return mktime(&date) + (sec - date.tm_sec);
+    } else {
+      return timegm(&date) + (sec - date.tm_sec);
+    }
   }
 
   double valueTime(int j) {

--- a/src/PqRow.h
+++ b/src/PqRow.h
@@ -100,9 +100,9 @@ public:
     return bytes;
   }
 
-  int valueDate(int j) {
+  double valueDate(int j) {
     if (valueNull(j)) {
-      return NA_INTEGER;
+      return NA_REAL;
     }
     char* val = PQgetvalue(pRes_, 0, j);
     struct tm date = { 0 };
@@ -198,7 +198,7 @@ public:
       SET_STRING_ELT(x, i, valueString(j));
       break;
     case PGDate:
-      INTEGER(x)[i] = valueDate(j);
+      REAL(x)[i] = valueDate(j);
       break;
     case PGDatetimeTZ:
       REAL(x)[i] = valueDatetime(j, false);

--- a/src/PqUtils.h
+++ b/src/PqUtils.h
@@ -54,8 +54,6 @@ Rcpp::List inline dfCreate(const std::vector<PGTypes>& types, const std::vector<
   for (std::vector<PGTypes>::const_iterator it = types.begin(); it != types.end(); ++it, j++) {
       switch (*it) {
       case PGDate:
-          out[j] = Rf_allocVector(INTSXP, n);
-          break;
       case PGDatetime:
       case PGDatetimeTZ:
       case PGTime:

--- a/src/PqUtils.h
+++ b/src/PqUtils.h
@@ -21,6 +21,10 @@ enum PGTypes {
   PGString = STRSXP,
   PGLogical = LGLSXP,
   PGVector = VECSXP,
+  PGDate,
+  PGDatetime,
+  PGDatetimeTZ,
+  PGTime
 };
 
 Rcpp::List inline dfResize(Rcpp::List df, int n) {
@@ -49,6 +53,14 @@ Rcpp::List inline dfCreate(const std::vector<PGTypes>& types, const std::vector<
   int j = 0;
   for (std::vector<PGTypes>::const_iterator it = types.begin(); it != types.end(); ++it, j++) {
       switch (*it) {
+      case PGDate:
+          out[j] = Rf_allocVector(INTSXP, n);
+          break;
+      case PGDatetime:
+      case PGDatetimeTZ:
+      case PGTime:
+          out[j] = Rf_allocVector(REALSXP, n);
+          break;
       default:
           out[j] = Rf_allocVector(static_cast<SEXPTYPE>(*it), n);
       }

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -22,12 +22,6 @@ DBItest::test_all(c(
   "data_character",                             # #50
   "data_raw",                                   # #66
   "data_raw_null_.*",                           # #66
-  "data_date_typed",                            # #52
-  "data_date_current_typed",                    # #52
-  "data_timestamp",                             #
-  "data_timestamp_typed",                       # #53
-  "data_timestamp_current_typed",               # #53
-  "data_timestamp_utc_typed",                   # #53
 
   # sql
   "quote_string.*",                             # #50
@@ -41,6 +35,7 @@ DBItest::test_all(c(
   "roundtrip_64_bit_.*",                 # rstats-db/DBI#48
   "roundtrip_raw",                              # #66
   "roundtrip_blob",                             # #66
+  "roundtrip_time",                             # #61
   "roundtrip_numeric_special",                  #
   "read_table_check_names",                     #
   "read_table_error",                           #

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -24,11 +24,9 @@ DBItest::test_all(c(
   "data_raw_null_.*",                           # #66
   "data_date_typed",                            # #52
   "data_date_current_typed",                    # #52
-  "data_timestamp",                             #
   "data_timestamp_typed",                       # #53
   "data_timestamp_current_typed",               # #53
   "data_timestamp_utc_typed",                   # #53
-  "data_timestamp_null_.*",                     # #53
 
   # sql
   "quote_string.*",                             # #50

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -24,6 +24,7 @@ DBItest::test_all(c(
   "data_raw_null_.*",                           # #66
   "data_date_typed",                            # #52
   "data_date_current_typed",                    # #52
+  "data_timestamp",                             #
   "data_timestamp_typed",                       # #53
   "data_timestamp_current_typed",               # #53
   "data_timestamp_utc_typed",                   # #53
@@ -40,9 +41,6 @@ DBItest::test_all(c(
   "roundtrip_64_bit_.*",                 # rstats-db/DBI#48
   "roundtrip_raw",                              # #66
   "roundtrip_blob",                             # #66
-  "roundtrip_date",                             # #61
-  "roundtrip_time",                             # #61
-  "roundtrip_timestamp",                        # #61
   "roundtrip_numeric_special",                  #
   "read_table_check_names",                     #
   "read_table_error",                           #


### PR DESCRIPTION
This supersedes PR #25, and does the date conversions in C++ directly. This still might not be the most efficient way to do things, since apparently mktime is pretty slow as it is doing system calls to figure out what the local timezone is.
I represent times as hms, so I use a forked version of DBItest which handles this see thrasibule/DBItest@5950ad4. Using this branch, tests pass locally for me.