### PR TITLE
Handle bigint

### DIFF
--- a/src/PqResult.h
+++ b/src/PqResult.h
@@ -254,7 +254,6 @@ private:
       Oid type = PQftype(pSpec_, i);
       // SELECT oid, typname FROM pg_type WHERE typtype = 'b'
       switch(type) {
-      case 20: // BIGINT
       case 21: // SMALLINT
       case 23: // INTEGER
       case 26: // OID
@@ -282,6 +281,7 @@ private:
       case 1266: // TIMETZOID
       case 3802: // JSONB
       case 2950: // UUID
+      case 20: // BIGINT -> R do not handle int8
         types.push_back(STRSXP);
         break;
 


### PR DESCRIPTION
Hey,

I had two surprises today:

1. bigint were not handle well by RPostgres (both pull & push). This lead to invisible error, and was difficult to debug eg: 8998329829898429834 -> 1878743324
2. When trying to modify the code, I learned that R do not handle int8. The usual solution is to cast them as character (https://www.r-bloggers.com/r-in-a-64-bit-world/)

Then find here the patch that handle postgresql bigint as strings. 
BTW, dbWriteTable will create TEXT field.

My guess is this is inevitable.
