### PR TITLE
only PQcancel if DbResult::complete() is false

### DIFF
--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -73,10 +73,7 @@ void DbConnection::cancel_query() {
   //  * the connection is NULL or
   //  * the connection is invalid.
   PGcancel* cancel = PQgetCancel(pConn_);
-  if (cancel == NULL) {
-    check_connection();  // should throw an error, but just in case...
-    stop("Connection error detected in PQgetCancel()");
-  }
+  if (cancel == NULL) stop("Connection error detected via PQgetCancel()");
 
   // PQcancel() actually issues the cancel command to the backend.
   char errbuf[256];
@@ -230,7 +227,7 @@ void DbConnection::conn_stop(PGconn* conn, const char* msg) {
 }
 
 void DbConnection::cleanup_query() {
-  if(pCurrentResult_ != NULL && !(const_cast<DbResult*>(pCurrentResult_))->complete()) {
+  if(pCurrentResult_ != NULL && !(pCurrentResult_->complete())) {
     cancel_query();
   }
   finish_query();

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -64,7 +64,7 @@ void DbConnection::set_current_result(const DbResult* pResult) {
  * https://www.postgresql.org/docs/9.6/static/libpq-cancel.html
  **/
 void DbConnection::cancel_query() {
-  warning("cancelling previous query");
+  warning("Cancelling previous query");
 
   check_connection();
 

--- a/src/DbResult.cpp
+++ b/src/DbResult.cpp
@@ -50,7 +50,7 @@ int DbResult::n_rows_fetched() {
   return impl->n_rows_fetched();
 }
 
-bool DbResult::complete() {
+bool DbResult::complete() const {
   return impl->complete();
 }
 

--- a/src/DbResult.h
+++ b/src/DbResult.h
@@ -25,7 +25,7 @@ public:
   ~DbResult();
 
 public:
-  bool complete();
+  bool complete() const;
   bool active() const;
   int n_rows_fetched();
   int n_rows_affected();

--- a/src/PqResultImpl.cpp
+++ b/src/PqResultImpl.cpp
@@ -170,7 +170,7 @@ void PqResultImpl::init(bool params_have_rows) {
 
 // Publics /////////////////////////////////////////////////////////////////////
 
-bool PqResultImpl::complete() {
+bool PqResultImpl::complete() const {
   return complete_;
 }
 

--- a/src/PqResultImpl.h
+++ b/src/PqResultImpl.h
@@ -47,7 +47,7 @@ private:
   void init(bool params_have_rows);
 
 public:
-  bool complete();
+  bool complete() const;
   int n_rows_fetched();
   int n_rows_affected();
   void bind(const List& params);


### PR DESCRIPTION
The test at line 220:
```c++
if(pCurrentResult_ != NULL && !(const_cast<DbResult*>(pCurrentResult_))->complete())
```
... is a little ugly, though the const_cast was needed since `pCurrentResult_` is declared as a `const *DbResult` but the method implementations don't expect a `const` `this`.
Rather than re-write a lot of the other code, I thought this was the path of least resistance. (Especially since `complete()` doesn't change anything in the `DbResult`, only gets a value; i.e. the const_cast is safe here.)

I also cleaned up some of the logic in `set_current_result`, since if we're setting a new result, regardless of that new result's value (i.e. even if it's NULL) we should try to clean-up the previous result.

Finally, I made a few changes to the `cancel_query()` function itself, as the comments didn't exactly reflect the documented pattern [described here](https://www.postgresql.org/docs/9.6/static/libpq-cancel.html). (I also placed a link to those docs in the comments for `cancel_query()`.)

So far in my own testing, this change works and still behaves nicely if folks try to issue a new query prior to calling `dbCleanResult()`.