### PR TITLE
Typname

### DIFF
--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -7,7 +7,7 @@ NULL
 #' @export
 setClass("PqConnection",
   contains = "DBIConnection",
-  slots = list(ptr = "externalptr", bigint = "character")
+  slots = list(ptr = "externalptr", bigint = "character", typnames = "data.frame")
 )
 
 # show()
@@ -147,8 +147,10 @@ setMethod("dbConnect", "PqDriver",
       ptr <- connection_create(names(opts), as.vector(opts))
     }
 
-    con <- new("PqConnection", ptr = ptr, bigint = bigint)
+    con <- new("PqConnection", ptr = ptr, bigint = bigint, typnames = data.frame())
     dbExecute(con, "SET TIMEZONE='UTC'")
+    con@typnames <- dbGetQuery(con, "SELECT oid, typname FROM pg_type")
+
     con
   })
 

--- a/R/PqResult.R
+++ b/R/PqResult.R
@@ -43,7 +43,8 @@ setMethod("dbGetRowsAffected", "PqResult", function(res, ...) {
 #' @rdname PqResult-class
 #' @export
 setMethod("dbColumnInfo", "PqResult", function(res, ...) {
-  result_column_info(res@ptr)
+  rci <- result_column_info(res@ptr)
+  merge(res@conn@typnames, rci, by = "oid")
 })
 
 #' Execute a SQL statement on a database connection

--- a/R/PqResult.R
+++ b/R/PqResult.R
@@ -44,7 +44,7 @@ setMethod("dbGetRowsAffected", "PqResult", function(res, ...) {
 #' @export
 setMethod("dbColumnInfo", "PqResult", function(res, ...) {
   rci <- result_column_info(res@ptr)
-  merge(res@conn@typnames, rci, by = "oid")
+  typeLookup(rci, res@conn)
 })
 
 #' Execute a SQL statement on a database connection
@@ -117,7 +117,8 @@ setMethod("dbFetch", "PqResult", function(res, n = -1, ..., row.names = FALSE) {
   if (is.infinite(n)) n <- -1
   if (trunc(n) != n) stopc("n must be a whole number")
   ret <- sqlColumnToRownames(result_fetch(res@ptr, n = n), row.names)
-  convert_bigint(ret, res@bigint)
+  ret <- convert_bigint(ret, res@bigint)
+  finalizeTypes(ret, res@conn)
 })
 
 convert_bigint <- function(ret, bigint) {
@@ -130,6 +131,49 @@ convert_bigint <- function(ret, bigint) {
   is_int64 <- which(vlapply(ret, inherits, "integer64"))
   ret[is_int64] <- lapply(ret[is_int64], fun)
   ret
+}
+
+finalizeTypes <- function(ret, conn) {
+  if(nrow(conn@typnames) < 1) return(ret)
+
+  typnames <- vapply(attr(ret, "oids"), typeLookup, character(1), conn)
+  types <- vapply(ret, class, character(1))
+  class_edit <- types %in% "character" & !typnames %in% "unknown"
+  ret[class_edit] <- mapply(appendClass, ret[class_edit], typnames[class_edit], SIMPLIFY = FALSE)
+  ret[] <- lapply(ret, finalizeType)
+  structure(ret, oids = NULL)
+}
+
+appendClass <- function(x, .class) {
+  structure(x, class = c(.class, class(x)))
+}
+
+yankClass <- function(x) {
+  if(length(class(x)) < 2) return(x)
+  structure(x, class = class(x)[-1])
+}
+
+typeLookup <- function(x, conn) {
+  with(conn@typnames, typname[oid == x])
+}
+
+#' Finalize Type Coercion
+#'
+#' This can be used by other packages to coerce types to specific types.
+#' @param x a list or vector column who's class is from the `pg_types` table
+#' @param ... extra arguments
+#' @details Add a generic method using `finalizeType.<typname>` where `<typname>`
+#' is taken from the `pg_types` table.
+#' @examples
+#' finalizeType.json <- function(x, ...) {
+#'   lapply(x, jsonlite::fromJSON)
+#' }
+#' dbGetQuery(conn, "SELECT 1 as a, '[1,2,3]'::json as js")
+#' @rdname quote
+finalizeType <- function(x, ...) UseMethod("finalizeType")
+
+finalizeType.default <- function(x, ...) {
+  yankClass(x)
 }
 
 #' @rdname postgres-query

--- a/src/DbDataFrame.cpp
+++ b/src/DbDataFrame.cpp
@@ -8,10 +8,11 @@
 #include <boost/range/algorithm_ext/for_each.hpp>
 
 DbDataFrame::DbDataFrame(DbColumnDataSourceFactory* factory_, std::vector<std::string> names_, const int n_max_,
-                         const std::vector<DATA_TYPE>& types_)
+                         const std::vector<DATA_TYPE>& types_, std::vector<Oid> oids_)
   : n_max(n_max_),
     i(0),
-    names(names_)
+    names(names_),
+    oids(oids_)
 {
   factory.reset(factory_);
 
@@ -57,7 +58,15 @@ List DbDataFrame::get_data(std::vector<DATA_TYPE>& types_) {
   out.attr("names") = names;
   out.attr("class") = "data.frame";
   out.attr("row.names") = IntegerVector::create(NA_INTEGER, -i);
+  out.attr("oids") = as<IntegerVector>(wrap(oids));
   return out;
+}
+
+std::vector<Oid> get_oids() {
+  std::vector<Oid> oids;
+  oids.push_back(Oid(991));
+  oids.push_back(Oid(992));
+  return(oids);
 }
 
 size_t DbDataFrame::get_ncols() const {

--- a/src/DbDataFrame.h
+++ b/src/DbDataFrame.h
@@ -14,9 +14,14 @@ class DbDataFrame {
   int i;
   boost::container::stable_vector<DbColumn> data;
   std::vector<std::string> names;
+  std::vector<Oid> oids;
 
 public:
-  DbDataFrame(DbColumnDataSourceFactory* factory, std::vector<std::string> names, const int n_max_, const std::vector<DATA_TYPE>& types);
+  DbDataFrame(DbColumnDataSourceFactory* factory,
+              std::vector<std::string> names,
+              const int n_max_,
+              const std::vector<DATA_TYPE>& types,
+              std::vector<Oid> oids_);
   virtual ~DbDataFrame();
 
 public:

--- a/src/PqDataFrame.cpp
+++ b/src/PqDataFrame.cpp
@@ -3,9 +3,12 @@
 #include "PqColumnDataSourceFactory.h"
 
 
-PqDataFrame::PqDataFrame(PqResultSource* result_source, const std::vector<std::string>& names, const int n_max_,
-                         const std::vector<DATA_TYPE>& types) :
-  DbDataFrame(new PqColumnDataSourceFactory(result_source, types), names, n_max_, types)
+PqDataFrame::PqDataFrame(PqResultSource* result_source,
+                         const std::vector<std::string>& names,
+                         const int n_max_,
+                         const std::vector<DATA_TYPE>& types,
+                         std::vector<Oid> oids) :
+  DbDataFrame(new PqColumnDataSourceFactory(result_source, types), names, n_max_, types, oids)
 {
 }
 

--- a/src/PqDataFrame.h
+++ b/src/PqDataFrame.h
@@ -7,8 +7,11 @@ class PqResultSource;
 
 class PqDataFrame : public DbDataFrame {
 public:
-  PqDataFrame(PqResultSource* result_source, const std::vector<std::string>& names, const int n_max_,
-              const std::vector<DATA_TYPE>& types);
+  PqDataFrame(PqResultSource* result_source,
+              const std::vector<std::string>& names,
+              const int n_max_,
+              const std::vector<DATA_TYPE>& types,
+              std::vector<Oid> oids);
   ~PqDataFrame();
 };
 

--- a/src/PqResultImpl.h
+++ b/src/PqResultImpl.h
@@ -20,6 +20,7 @@ class PqResultImpl : boost::noncopyable, public PqResultSource {
   struct _cache {
     const std::vector<std::string> names_;
     const std::vector<DATA_TYPE> types_;
+    const std::vector<Oid> oids_;
     const size_t ncols_;
     const int nparams_;
 
@@ -27,6 +28,7 @@ class PqResultImpl : boost::noncopyable, public PqResultSource {
 
     static std::vector<std::string> get_column_names(PGresult* spec);
     static std::vector<DATA_TYPE> get_column_types(PGresult* spec);
+    static std::vector<Oid> get_column_oids(PGresult* spec);
   } cache;
 
   // State

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -1,0 +1,29 @@
+context("exotic types")
+
+test_that("can manipulate classes", {
+  expect_is(set_class(1, "A"), "A")
+  expect_is(append_class(1, "A"), "A")
+  expect_is(yank_class(append_class(1, "A")), "numeric")
+})
+
+test_that("`dbColumnInfo` knows about typnames", {
+  con <- postgresDefault()
+  on.exit(dbDisconnect(con))
+
+  z <- dbSendQuery(con, "SELECT 1 as a, '[1,2,3]'::json as js")
+  expect_equal(dbColumnInfo(z)[["typname"]], c("int4", "json"))
+})
+
+test_that("can finalize special types", {
+  df_ <- data.frame(a = 1, js = "[1,2,3]", stringsAsFactors = FALSE)
+  df <- dbGetQuery(con, "SELECT 1 as a, '[1,2,3]'::json as js")
+  expect_equal(df, df_)
+
+  finalizeType.json <- function(x, ...) {
+    lapply(x, jsonlite::fromJSON)
+  }
+
+  df_$js <- list(1:3); row.names(df_) <- 1L
+  df <- dbGetQuery(con, "SELECT 1 as a, '[1,2,3]'::json as js")
+  expect_equal(df, df_)
+})


### PR DESCRIPTION
@krlmlr I'm opening this P/R so you can have some visibility. Let me know how it looks so far. 

A few highlights to help you navigate changes:
* Exposes a hook named `finalizeType`, a generic S3 method, to make it easy for other packages to add types. 
* The `pg_types` are cached in the `PqConnection` object.
* I surfaced the oids using an attribute to the ` DbDataFrame`, maybe you will see something better, (I wasn't sure about my choice)
* There are probably existing functions I could use to `finalizeTypes`, `typeLookup`,  `append` and `yankClass`.

#114, r-dbi/DBI#203