### PR TITLE
change test from REAL to DOUBLE PRECISION

### DIFF
--- a/tests/testthat/test-data-type.R
+++ b/tests/testthat/test-data-type.R
@@ -8,5 +8,5 @@ test_that("dbDataType works on a data frame", {
   df <- data.frame(x = 1:10, y = 1:10 / 2)
   types <- dbDataType(con, df)
 
-  expect_equal(types, c(x = "INTEGER", y = "REAL"))
+  expect_equal(types, c(x = "INTEGER", y = "DOUBLE PRECISION"))
 })


### PR DESCRIPTION
Resolve issue in test case caused by _Translate floating-point values to `DOUBLE PRECISION`_ on Nov 26 in this commit:  https://github.com/r-dbi/RPostgres/commit/67449d5d64ef36ad200f4abb5226663a31735d2a

