### PR TITLE
Improve timezone handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     blob (>= 1.2.0),
     DBI (>= 1.1.0),
     hms (>= 0.5.0),
+    lubridate,
     methods,
     Rcpp (>= 0.11.4.2),
     withr

--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -186,7 +186,9 @@ setMethod("dbConnect", "PqDriver",
     }
     bigint <- match.arg(bigint)
     stopifnot(is.logical(check_interrupts), all(!is.na(check_interrupts)), length(check_interrupts) == 1)
-    stopifnot(is.character(timezone), all(!is.na(timezone)), length(timezone) == 1)
+    if (!is.null(timezone)) {
+      stopifnot(is.character(timezone), all(!is.na(timezone)), length(timezone) == 1)
+    }
 
     if (length(opts) == 0) {
       ptr <- connection_create(character(), character(), check_interrupts)

--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -7,7 +7,12 @@ NULL
 #' @export
 setClass("PqConnection",
   contains = "DBIConnection",
-  slots = list(ptr = "externalptr", bigint = "character", typnames = "data.frame")
+  slots = list(
+    ptr = "externalptr",
+    bigint = "character",
+    timezone = "character",
+    typnames = "data.frame"
+  )
 )
 
 # format()
@@ -176,6 +181,7 @@ setMethod("dbConnect", "PqDriver",
     }
     bigint <- match.arg(bigint)
     stopifnot(is.logical(check_interrupts), all(!is.na(check_interrupts)), length(check_interrupts) == 1)
+    stopifnot(is.character(timezone), all(!is.na(timezone)), length(timezone) == 1)
 
     if (length(opts) == 0) {
       ptr <- connection_create(character(), character(), check_interrupts)
@@ -183,12 +189,38 @@ setMethod("dbConnect", "PqDriver",
       ptr <- connection_create(names(opts), as.vector(opts), check_interrupts)
     }
 
-    conn <- new("PqConnection", ptr = ptr, bigint = bigint, typnames = data.frame())
+    # timezone is set later
+    conn <- new("PqConnection",
+      ptr = ptr, bigint = bigint, timezone = character(), typnames = data.frame()
+    )
+    on.exit(dbDisconnect(conn))
+
     if (!is.null(timezone)) {
-      dbExecute(conn, paste0("SET TIMEZONE='", timezone, "'"))
+      # Side effect: check if time zone valid
+      dbExecute(conn, paste0("SET TIMEZONE = '", timezone, "'"))
+    } else {
+      timezone <- dbGetQuery(conn, "SHOW timezone")[[1]]
     }
+
+    # Check if this is a valid time zone in R:
+    tryCatch(
+      lubridate::force_tz(as.POSIXct("2021-03-01 10:40"), timezone),
+      error = function(e) {
+        warning(
+          "Invalid time zone '", timezone, "', ",
+          "falling back to local time.\n",
+          "Set the `timezone` argument to a valid time zone.\n",
+          conditionMessage(e),
+          call. = FALSE
+        )
+        timezone <- ""
+      }
+    )
+
+    conn@timezone <- timezone
     conn@typnames <- dbGetQuery(conn, "SELECT oid, typname FROM pg_type")
 
+    on.exit(NULL)
     conn
   })
 

--- a/R/PqResult.R
+++ b/R/PqResult.R
@@ -150,8 +150,18 @@ finalize_types <- function(ret, conn) {
     ret[is_unknown] <- Map(set_class, ret[is_unknown], typname_classes)
   }
 
+  is_without_tz <- which(attr(ret, "without_tz"))
+  if (length(is_without_tz) > 0) {
+    ret[is_without_tz] <- lapply(ret[is_without_tz], function(x) {
+      x <- lubridate::with_tz(x, "UTC")
+      lubridate::force_tz(x, conn@timezone)
+    })
+  }
+
   attr(ret, "oids") <- NULL
   attr(ret, "known") <- NULL
+  attr(ret, "without_tz") <- NULL
+
   ret
 }
 

--- a/R/PqResult.R
+++ b/R/PqResult.R
@@ -158,6 +158,11 @@ finalize_types <- function(ret, conn) {
     })
   }
 
+  is_datetime <- which(vapply(ret, inherits, "POSIXt", FUN.VALUE = logical(1)))
+  if (length(is_datetime) > 0) {
+    ret[is_datetime] <- lapply(ret[is_datetime], lubridate::with_tz, conn@timezone_out)
+  }
+
   attr(ret, "oids") <- NULL
   attr(ret, "known") <- NULL
   attr(ret, "without_tz") <- NULL

--- a/man/Postgres.Rd
+++ b/man/Postgres.Rd
@@ -19,7 +19,8 @@ Postgres()
   ...,
   bigint = c("integer64", "integer", "numeric", "character"),
   check_interrupts = FALSE,
-  timezone = "UTC"
+  timezone = "UTC",
+  timezone_out = timezone
 )
 
 \S4method{dbDisconnect}{PqConnection}(conn, ...)
@@ -61,7 +62,12 @@ first row of data is available)? Setting to \code{TRUE} allows interruption of q
 running too long.}
 
 \item{timezone}{Sets the timezone for the connection. The default is \code{"UTC"}.
-If \code{NULL} then no timezone is set, which defaults to localtime.}
+If \code{NULL} then no timezone is set, which defaults to the server's time zone.}
+
+\item{timezone_out}{The time zone returned to R, defaults to \code{timezone}.
+If you want to display datetime values in the local timezone,
+set to \code{\link[=Sys.timezone]{Sys.timezone()}} or \code{""}.
+This setting does not change the time values returned, only their display.}
 
 \item{conn}{Connection to disconnect.}
 }

--- a/man/Redshift.Rd
+++ b/man/Redshift.Rd
@@ -70,7 +70,7 @@ first row of data is available)? Setting to \code{TRUE} allows interruption of q
 running too long.}
 
 \item{timezone}{Sets the timezone for the connection. The default is \code{"UTC"}.
-If \code{NULL} then no timezone is set, which defaults to localtime.}
+If \code{NULL} then no timezone is set, which defaults to the server's time zone.}
 }
 \description{
 Redshift currently uses all the same method as Postgres, but allows

--- a/man/quote.Rd
+++ b/man/quote.Rd
@@ -8,7 +8,6 @@
 \alias{dbQuoteIdentifier,PqConnection,SQL-method}
 \alias{dbQuoteIdentifier,PqConnection,Id-method}
 \alias{dbUnquoteIdentifier,PqConnection,SQL-method}
-\alias{dbQuoteLiteral}
 \alias{dbQuoteLiteral,PqConnection,logical-method}
 \alias{dbQuoteLiteral,PqConnection,integer-method}
 \alias{dbQuoteLiteral,PqConnection,numeric-method}
@@ -32,8 +31,6 @@
 \S4method{dbQuoteIdentifier}{PqConnection,Id}(conn, x, ...)
 
 \S4method{dbUnquoteIdentifier}{PqConnection,SQL}(conn, x, ...)
-
-dbQuoteLiteral(conn, x, ...)
 
 \S4method{dbQuoteLiteral}{PqConnection,logical}(conn, x, ...)
 

--- a/src/PqColumnDataSource.cpp
+++ b/src/PqColumnDataSource.cpp
@@ -111,7 +111,6 @@ double PqColumnDataSource::fetch_time() const {
 }
 
 double PqColumnDataSource::convert_datetime(const char* val, bool use_local) {
-  char* end;
   struct tm date;
   date.tm_isdst = -1;
   date.tm_year = *val++ - 0x30;

--- a/src/PqColumnDataSource.cpp
+++ b/src/PqColumnDataSource.cpp
@@ -155,15 +155,21 @@ double PqColumnDataSource::convert_datetime(const char* val) {
   if (*val == '+' || *val == '-') {
     int tz_hours = 0, tz_minutes = 0, sign = 0;
     sign = (*val++ == '+' ? +1 : -1);
+    LOG_VERBOSE << sign;
+
     tz_hours = (*val++ - 0x30) * 10;
     tz_hours += (*val++ - 0x30);
+    LOG_VERBOSE << tz_hours;
 
     if (*val == ':') {
+      ++val;
       tz_minutes = (*val++ - 0x30) * 10;
       tz_minutes += (*val++ - 0x30);
+      LOG_VERBOSE << tz_minutes;
     }
 
     utcoffset = sign * (tz_hours * 3600 + tz_minutes * 60);
+    LOG_VERBOSE << utcoffset;
   }
 
   time_t time = tm_to_time_t(date);

--- a/src/PqColumnDataSource.cpp
+++ b/src/PqColumnDataSource.cpp
@@ -152,6 +152,7 @@ double PqColumnDataSource::convert_datetime(const char* val, bool use_local) {
   date.tm_sec = static_cast<int>(sec);
   LOG_VERBOSE << date.tm_sec;
 
+  int utcoffset = 0;
   if (*val == '+' || *val == '-') {
     int tz_hours = 0, tz_minutes = 0, sign = 0;
     sign = (*val++ == '+' ? +1 : -1);

--- a/src/PqColumnDataSource.cpp
+++ b/src/PqColumnDataSource.cpp
@@ -114,46 +114,62 @@ double PqColumnDataSource::convert_datetime(const char* val, bool use_local) {
   char* end;
   struct tm date;
   date.tm_isdst = -1;
-  date.tm_year = *val - 0x30;
+  date.tm_year = *val++ - 0x30;
   date.tm_year *= 10;
-  date.tm_year += (*(++val) - 0x30);
+  date.tm_year += (*val++ - 0x30);
   date.tm_year *= 10;
-  date.tm_year += (*(++val) - 0x30);
+  date.tm_year += (*val++ - 0x30);
   date.tm_year *= 10;
-  date.tm_year += (*(++val) - 0x30) - 1900;
+  date.tm_year += (*val++ - 0x30) - 1900;
   LOG_VERBOSE << date.tm_year;
 
   val++;
-  date.tm_mon = (*(++val) - 0x30) * 10;
-  date.tm_mon += (*(++val) - 0x30) - 1;
+  date.tm_mon = (*val++ - 0x30) * 10;
+  date.tm_mon += (*val++ - 0x30) - 1;
   LOG_VERBOSE << date.tm_mon;
 
   val++;
-  date.tm_mday = (*(++val) - 0x30) * 10;
-  date.tm_mday += (*(++val) - 0x30);
+  date.tm_mday = (*val++ - 0x30) * 10;
+  date.tm_mday += (*val++ - 0x30);
   LOG_VERBOSE << date.tm_mday;
 
   val++;
-  date.tm_hour = (*(++val) - 0x30) * 10;
-  date.tm_hour += (*(++val) - 0x30);
+  date.tm_hour = (*val++ - 0x30) * 10;
+  date.tm_hour += (*val++ - 0x30);
   LOG_VERBOSE << date.tm_hour;
 
   val++;
-  date.tm_min = (*(++val) - 0x30) * 10;
-  date.tm_min += (*(++val) - 0x30);
+  date.tm_min = (*val++ - 0x30) * 10;
+  date.tm_min += (*val++ - 0x30);
   LOG_VERBOSE << date.tm_min;
 
   val++;
-  double sec = strtod(++val, &end);
+  char* end;
+  double sec = strtod(val, &end);
+  val = end;
   LOG_VERBOSE << sec;
 
   date.tm_sec = static_cast<int>(sec);
   LOG_VERBOSE << date.tm_sec;
 
-  time_t time = use_local ? mktime(&date) : tm_to_time_t(date);
+  if (*val == '+' || *val == '-') {
+    int tz_hours = 0, tz_minutes = 0, sign = 0;
+    sign = (*val++ == '+' ? +1 : -1);
+    tz_hours = (*val++ - 0x30) * 10;
+    tz_hours += (*val++ - 0x30);
+
+    if (*val == ':') {
+      tz_minutes = (*val++ - 0x30) * 10;
+      tz_minutes += (*val++ - 0x30);
+    }
+
+    utcoffset = sign * (tz_hours * 3600 + tz_minutes * 60);
+  }
+
+  time_t time = tm_to_time_t(date);
   LOG_VERBOSE << time;
 
-  double ret = static_cast<double>(time) + (sec - date.tm_sec);
+  double ret = static_cast<double>(time) + (sec - date.tm_sec) - utcoffset;
   LOG_VERBOSE << ret;
 
   return ret;

--- a/src/PqColumnDataSource.cpp
+++ b/src/PqColumnDataSource.cpp
@@ -89,12 +89,12 @@ double PqColumnDataSource::fetch_date() const {
 
 double PqColumnDataSource::fetch_datetime_local() const {
   LOG_VERBOSE;
-  return convert_datetime(get_result_value(), true);
+  return convert_datetime(get_result_value());
 }
 
 double PqColumnDataSource::fetch_datetime() const {
   LOG_VERBOSE;
-  return convert_datetime(get_result_value(), false);
+  return convert_datetime(get_result_value());
 }
 
 double PqColumnDataSource::fetch_time() const {
@@ -110,7 +110,7 @@ double PqColumnDataSource::fetch_time() const {
   return static_cast<double>(hour * 3600 + min * 60) + sec;
 }
 
-double PqColumnDataSource::convert_datetime(const char* val, bool use_local) {
+double PqColumnDataSource::convert_datetime(const char* val) {
   struct tm date;
   date.tm_isdst = -1;
   date.tm_year = *val++ - 0x30;

--- a/src/PqColumnDataSource.h
+++ b/src/PqColumnDataSource.h
@@ -32,7 +32,7 @@ public:
   virtual double fetch_time() const;
 
 private:
-  static double convert_datetime(const char* val, bool use_local);
+  static double convert_datetime(const char* val);
   PGresult* get_result() const;
   const char* get_result_value() const;
 };

--- a/src/PqResultImpl.cpp
+++ b/src/PqResultImpl.cpp
@@ -462,6 +462,14 @@ void PqResultImpl::bind() {
 void PqResultImpl::add_oids(List& data) const {
   data.attr("oids") = cache.oids_;
   data.attr("known") = cache.known_;
+
+  LogicalVector is_without_tz = LogicalVector(cache.types_.size());
+  for (size_t i = 0; i < cache.types_.size(); ++i) {
+    bool set = (cache.types_[i] == DT_DATETIME);
+    LOG_VERBOSE << "is_without_tz[" << i << "]: " << set;
+    is_without_tz[i] = set;
+  }
+  data.attr("without_tz") = is_without_tz;
 }
 
 PGresult* PqResultImpl::get_result() {

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -15,8 +15,8 @@ DBItest::make_context(
   default_skip = c(
     if (packageVersion("DBItest") < "1.7.0.9002") "compliance",
 
-    if (.Platform$r_arch == "i386") "append_roundtrip_timestamp",
-    if (.Platform$r_arch == "i386") "roundtrip_timestamp",
+    if (packageVersion("DBItest") < "1.7.0.9010") "append_roundtrip_timestamp",
+    if (packageVersion("DBItest") < "1.7.0.9010") "roundtrip_timestamp",
 
     NULL
   )

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -124,3 +124,12 @@ test_that("timezone is passed on to the connection (#229)", {
   res <- dbGetQuery(con, query)
   expect_equal(res, expected)
 })
+
+test_that("warning if time zone not interpretable", {
+  skip_on_cran()
+
+  expect_warning(con <- postgresDefault(timezone = "+01:00"))
+  dbDisconnect(con)
+  expect_warning(con <- postgresDefault(timezone_out = "+01:00"))
+  dbDisconnect(con)
+})

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -1,0 +1,88 @@
+test_that("timestamp without time zone is returned correctly for TZ set (#190)", {
+  withr::local_timezone("America/Chicago")
+
+  query <- "SELECT '2018-01-01 12:30:00'::TIMESTAMP"
+
+  db <- postgresDefault(timezone = "America/Chicago")
+  expect_equal(
+    dbGetQuery(db, query)[[1]],
+    as.POSIXct("2018-01-01 12:30:00", tz = "America/Chicago")
+  )
+  dbDisconnect(db)
+
+  db <- postgresDefault(timezone = "America/New_York")
+  expect_equal(
+    dbGetQuery(db, query)[[1]],
+    as.POSIXct("2018-01-01 12:30:00", tz = "America/New_York")
+  )
+  dbDisconnect(db)
+
+  db <- postgresDefault(timezone = "Europe/London")
+  expect_equal(
+    dbGetQuery(db, query)[[1]],
+    as.POSIXct("2018-01-01 12:30:00", tz = "Europe/London")
+  )
+  dbDisconnect(db)
+
+  db <- postgresDefault(timezone = "Europe/Zurich")
+  expect_equal(
+    dbGetQuery(db, query)[[1]],
+    as.POSIXct("2018-01-01 12:30:00", tz = "Europe/Zurich")
+  )
+  dbDisconnect(db)
+})
+
+test_that("timestamp with time zone is returned correctly (#205)", {
+  con <- postgresDefault()
+  on.exit(dbDisconnect(con))
+
+  withr::local_timezone("America/New_York")
+
+  con <- postgresDefault(timezone = "America/Chicago")
+
+  query <- "CREATE TEMPORARY TABLE junk AS
+            (SELECT '2020-05-04'::TIMESTAMPTZ AS ts)"
+  res <- dbExecute(con, query)
+
+  res <- dbGetQuery(con, "SELECT * FROM junk")
+  expect_equal(res[[1]], as.POSIXct("2020-05-04", tz = "America/Chicago"))
+})
+
+test_that("timestamp without time zone is returned correctly (#221)", {
+  con <- postgresDefault()
+  on.exit(dbDisconnect(con))
+
+  out <- dbGetQuery(con, "SELECT CAST('1960-01-01 12:00:00' AS timestamp) AS before_epoch")
+  expect_equal(as.Date(out[[1]]), as.Date("1960-01-01"))
+})
+
+test_that("timezone is passed on to the connection (#229)", {
+  my_tz <- "US/Alaska"
+
+  con <- postgresDefault(timezone = my_tz)
+  on.exit(dbDisconnect(con))
+
+  example <- data.frame(val = 0:71)
+  example$ts <-
+    lubridate::ymd_hms("2019-04-30 00:00:00", tz = my_tz) +
+    lubridate::hours(example$val)
+
+  dbWriteTable(
+    con, "example", example, temporary = TRUE,
+    overwrite = TRUE, append = FALSE
+  )
+
+  query <- '
+    SELECT date("ts") AS "dte", MIN("val") AS "min", MAX("val") AS "max"
+    FROM "example"
+    GROUP BY "dte"
+    ORDER BY "dte"'
+  expected <- data.frame(
+    dte = as.Date("2019-04-30") + 0:2,
+    min = 0:2 * 24,
+    max = 0:2 * 24 + 23
+  )
+
+  res <- dbGetQuery(con, query)
+  expect_equal(res, expected)
+})


### PR DESCRIPTION
- Parse timezone information returned from RPostgres
- Set timezone to server timezone for `DATETIME` (=without time zone) values
- Add `timezone_out` argument
- Now requires lubridate to avoid copying cctz

Closes #190. Closes #205. Closes #221. Closes #222. Closes #229.