### PR TITLE
Fix typo

### DIFF
--- a/configure
+++ b/configure
@@ -30,7 +30,7 @@ if [ `command -v pkg-config` ]; then
         unset PKGCONFIG_LIBS
       ;;
     esac
-    if [ -z "$PKGCONFIG_CFLAGS" ]]; then
+    if [ -z "$PKGCONFIG_CFLAGS" ]; then
       unset PKGCONFIG_LIBS
     fi
   fi


### PR DESCRIPTION
I think this causes https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/RPostgres-00install.html