### PR TITLE
Fix configure

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@ windows
 ^LICENSE\.md$
 ^CODE_OF_CONDUCT\.md$
 ^tests/testthat/testthat-problems\.rds$
+^.*\.log$

--- a/configure
+++ b/configure
@@ -86,10 +86,10 @@ echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"
 
 # Test configuration
-echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>&1 || R_CONFIG_ERROR=1;
+echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2> configure.log
 
 # Customize the error
-if [ $R_CONFIG_ERROR ]; then
+if [ $? -ne 0 ]; then
   echo "------------------------- ANTICONF ERROR ---------------------------"
   echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"
   echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"

--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ if [ -z "$FORCE_AUTOBREW" ] && [ `command -v pkg-config` ]; then
   PKGCONFIG_LIBS=`pkg-config --libs --silence-errors ${PKG_CONFIG_NAME}`
   PKGCONFIG_MODVERSION=`pkg-config --modversion --silence-errors ${PKG_CONFIG_NAME}`
 
-  # MacOS seems to ship a broken libpq.pc file
+  # Workaround for broken libpq.pc files on some systems
   if [ `uname` = "Darwin" ]; then
     case "$PKGCONFIG_CFLAGS" in
       *"Internal.sdk"*)

--- a/configure
+++ b/configure
@@ -17,7 +17,7 @@ PKG_TEST_HEADER="<libpq-fe.h>"
 PKG_LIBS="-lpq"
 
 # pkg-config values (if available)
-if [ `command -v pkg-config` ]; then
+if [ -z "$FORCE_AUTOBREW" ] && [ `command -v pkg-config` ]; then
   PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
   PKGCONFIG_LIBS=`pkg-config --libs --silence-errors ${PKG_CONFIG_NAME}`
   PKGCONFIG_MODVERSION=`pkg-config --modversion --silence-errors ${PKG_CONFIG_NAME}`
@@ -37,7 +37,7 @@ if [ `command -v pkg-config` ]; then
 fi
 
 # pg_config values (if available)
-if [ `command -v pg_config` ]; then
+if [ -z "$FORCE_AUTOBREW" ] && [ `command -v pg_config` ]; then
   PG_INC_DIR=`pg_config --includedir`
   PG_LIB_DIR=`pg_config --libdir`
   PG_VERSION=`pg_config --version`
@@ -66,10 +66,10 @@ elif [ "$PG_INC_DIR" ] || [ "$PG_LIB_DIR" ]; then
   PKG_LIBS="-L${PG_LIB_DIR} ${PKG_LIBS}"
 elif [ `uname` = "Darwin" ]; then
   brew --version 2>/dev/null
-  if [ $? -eq 0 ]; then
+  if [ $? -eq 0 ] && [ -z "$FORCE_AUTOBREW" ]; then
     BREWDIR=`brew --prefix`
-  PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
-  PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
+    PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
+    PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
   else
     curl -sfL "https://autobrew.github.io/scripts/libpq" > autobrew
     . ./autobrew


### PR DESCRIPTION
In https://github.com/r-dbi/RPostgres/commit/620d011ee57aa70050a2f4b666bbb1cfd6259bba you seem to have copied some partial changes, but we need this part as well because later down we `cat configure.log` in case of failure.