### PR TITLE
Fix check_tz to return desired result when timezone is invalid

### DIFF
--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -233,7 +233,11 @@ check_tz <- function(timezone) {
   arg_name <- deparse(substitute(timezone))
 
   tryCatch(
-    lubridate::force_tz(as.POSIXct("2021-03-01 10:40"), timezone),
+    {
+      # Side effect: check if time zone is valid
+      lubridate::force_tz(as.POSIXct("2021-03-01 10:40"), timezone)
+      timezone
+    },
     error = function(e) {
       warning(
         "Invalid time zone '", timezone, "', ",
@@ -242,11 +246,9 @@ check_tz <- function(timezone) {
         conditionMessage(e),
         call. = FALSE
       )
-      timezone <<- ""
+      ""
     }
   )
-
-  timezone
 }
 
 # dbDisconnect() (after dbConnect() to maintain order in documentation)

--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -242,7 +242,7 @@ check_tz <- function(timezone) {
         conditionMessage(e),
         call. = FALSE
       )
-      timezone <- ""
+      timezone <<- ""
     }
   )
 

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -125,7 +125,9 @@ test_that("warning if time zone not interpretable", {
   skip_on_cran()
 
   expect_warning(con <- postgresDefault(timezone = "+01:00"))
+  expect_equal(con@timezone, "")
   dbDisconnect(con)
   expect_warning(con <- postgresDefault(timezone_out = "+01:00"))
+  expect_equal(con@timezone_out, "")
   dbDisconnect(con)
 })


### PR DESCRIPTION
A small thing I noticed:

When an invalid timezone is passed to the `timezone_out` argument in `dbConnect()`, the correct warning is thrown but the invalid timezone is kept due to a bug in `check_tz` (should be `""`):

``` r
library(RPostgres)

con <- postgresDefault(timezone = "+01:00")
#> Warning: Invalid time zone '+01:00', falling back to local time.
#> Set the `timezone` argument to a valid time zone.
#> CCTZ: Unrecognized output timezone: "+01:00"
con@timezone
#> [1] "+01:00"
dbDisconnect(con)

RPostgres:::check_tz("+01:00")
#> Warning: Invalid time zone '+01:00', falling back to local time.
#> Set the `"+01:00"` argument to a valid time zone.
#> CCTZ: Unrecognized output timezone: "+01:00"
#> [1] "+01:00"
```

<sup>Created on 2021-01-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR fixes this by assigning`timezone` to the parent env with `<<-` within `tryCatch` in `check_tz`, and adds a couple of new tests.