### PR TITLE
Use dbWriteTable Copy in dbAppendTable to Eliminate Slowdown

### DIFF
--- a/R/tables.R
+++ b/R/tables.R
@@ -193,7 +193,7 @@ setMethod("dbAppendTable", c("PqConnection"),
 
     row.names <- FALSE
 
-    value = factor_to_string(value)
+    value = factor_to_string(value, warn = TRUE)
 
     value <- sqlRownamesToColumn(value, row.names)
 

--- a/R/tables.R
+++ b/R/tables.R
@@ -24,6 +24,7 @@
 #'   and uses `COPY name FROM stdin`. This is fast, but not supported by
 #'   all postgres servers (e.g. Amazon's redshift). If `FALSE`, generates
 #'   a single SQL string. This is slower, but always supported.
+#' @param warn If `TRUE`, warns user when converting from factor to string.
 #'
 #' @examples
 #' # For running the examples on systems without PostgreSQL connection:

--- a/R/tables.R
+++ b/R/tables.R
@@ -193,6 +193,11 @@ setMethod("dbAppendTable", c("PqConnection"),
 
     row.names <- FALSE
 
+    is_factor = vlapply(value, is.factor)
+    if (any(is_factor)) {
+      warning("Factors converted to character", call. = FALSE)
+    }
+
     value <- sqlRownamesToColumn(value, row.names)
 
     value <- sql_data_copy(value, row.names = FALSE)

--- a/R/tables.R
+++ b/R/tables.R
@@ -193,10 +193,7 @@ setMethod("dbAppendTable", c("PqConnection"),
 
     row.names <- FALSE
 
-    is_factor = vlapply(value, is.factor)
-    if (any(is_factor)) {
-      warning("Factors converted to character", call. = FALSE)
-    }
+    value = factor_to_string(value)
 
     value <- sqlRownamesToColumn(value, row.names)
 

--- a/R/tables.R
+++ b/R/tables.R
@@ -204,6 +204,8 @@ setMethod("dbAppendTable", c("PqConnection"),
       " FROM STDIN"
     )
     connection_copy_data(conn@ptr, sql, value)
+
+    nrow(value)
   }
 )
 

--- a/man/postgres-tables.Rd
+++ b/man/postgres-tables.Rd
@@ -30,7 +30,15 @@
 
 \S4method{sqlData}{PqConnection}(con, value, row.names = FALSE, ...)
 
-\S4method{dbAppendTable}{PqConnection}(conn, name, value, ..., row.names = NULL)
+\S4method{dbAppendTable}{PqConnection}(
+  conn,
+  name,
+  value,
+  copy = TRUE,
+  warn = TRUE,
+  ...,
+  row.names = NULL
+)
 
 \S4method{dbReadTable}{PqConnection,character}(conn, name, ..., check.names = TRUE, row.names = FALSE)
 
@@ -89,6 +97,8 @@ all postgres servers (e.g. Amazon's redshift). If \code{FALSE}, generates
 a single SQL string. This is slower, but always supported.}
 
 \item{con}{A database connection.}
+
+\item{warn}{If \code{TRUE}, warns user when converting from factor to string.}
 
 \item{check.names}{If \code{TRUE}, the default, column names will be
 converted to valid R identifiers.}


### PR DESCRIPTION
This is a pull request to close https://github.com/r-dbi/RPostgres/issues/241 

The only change is to replace the dbAppendTable function with the relevant pieces of dbWriteTable when append & copy = TRUE.