### PR TITLE
Force autobrew libs on CRAN

### DIFF
--- a/configure
+++ b/configure
@@ -16,6 +16,11 @@ PKG_BREW_NAME="libpq"
 PKG_TEST_HEADER="<libpq-fe.h>"
 PKG_LIBS="-lpq"
 
+# Workaround for old libpq without ssl on CRAN servers
+if [ -d "/Volumes/Builds/packages" ] || [ -d "/Volumes/SSD-Data/Builds" ]; then
+FORCE_AUTOBREW=1
+fi
+
 # pkg-config values (if available)
 if [ -z "$FORCE_AUTOBREW" ] && [ `command -v pkg-config` ]; then
   PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`


### PR DESCRIPTION
Fixes #291.

This is what happened: CRAN recently [updated libpq on their server](https://github.com/R-macos/recipes/commit/2a186b954cf95b0169779cdbd9ad19f71c879da3) and now it exposes the `.pc` file. Therefore our package was picking up on that libpq, instead of the autobrew build. However the CRAN build is very old and does not support ssl.

