### PR TITLE
Extra checks for Macos

### DIFF
--- a/configure
+++ b/configure
@@ -16,6 +16,23 @@ PKG_BREW_NAME="libpq"
 PKG_TEST_HEADER="<libpq-fe.h>"
 PKG_LIBS="-lpq"
 
+# Extra checks on MacOS for SSL support in libpq
+if [ `uname` = "Darwin" ] && [ `command -v pkg-config` ]; then
+  if pkg-config --atleast-version=12 libpq; then
+    case "`pkg-config --libs --static libpq`" in
+    *crypto*)
+      echo "Local libpq has SSL support"
+      ;;
+    *)
+      echo "Local libpq does not have SSL support"
+      FORCE_AUTOBREW=1
+      ;;
+    esac
+  else
+    FORCE_AUTOBREW=1
+  fi
+fi
+
 # pkg-config values (if available)
 if [ -z "$FORCE_AUTOBREW" ] && [ `command -v pkg-config` ]; then
   PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`


### PR DESCRIPTION
Fixes https://github.com/r-dbi/RPostgres/issues/291 Closes https://github.com/r-dbi/RPostgres/pull/292

Another solution, specifically on MacOS, to prevent linking against outdated or non-ssl versions of libpq.