### PR TITLE
run scheduled workflows only in r-dbi repo

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -11,6 +11,7 @@ name: rcc dev
 
 jobs:
   matrix:
+    if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository_owner == 'r-dbi')
     runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ name: rcc
 
 jobs:
   R-CMD-check:
+    if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository_owner == 'r-dbi')
     runs-on: ${{ matrix.config.os }}${{ matrix.config.os-version }}
 
     name: ${{ matrix.config.os }}${{ matrix.config.os-version }} (${{ matrix.config.r }}) ${{ matrix.config.desc }}

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   lock:
+    if: github.repository_owner == 'r-dbi'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository_owner == 'r-dbi')
+    if: (github.repository_owner == 'r-dbi') || (github.event_name == 'pull_request')
     runs-on: ubuntu-18.04
 
     # Begin custom: services

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,6 +20,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository_owner == 'r-dbi')
     runs-on: ubuntu-18.04
 
     # Begin custom: services


### PR DESCRIPTION
The scheduled workflows currently run in forked repos as well. 
E.g. 144 workflow runs of the 158 in [my fork](https://github.com/dpprdan/RPostgres/actions) are scheduled runs.

![grafik](https://user-images.githubusercontent.com/1423562/113518834-04e35e80-9589-11eb-8910-87c9e19279bd.png)

Am I right to assume that this is neither necessary nor intended?

I therefore configured the workflows in such a way that they only run on a schedule in repositories owned by https://github.com/r-dbi. (Alternatively one could [condition on the repository](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context), i.e. `r-dbi/RPostgres`, but conditioning on the owner makes it easier to transfer to other r-dbi repos.)