### PR TITLE
Issue 244

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,4 +17,4 @@ development:
 
 authors:
   Kirill Müller:
-    href: http://krlmlr.info
+    href: https://krlmlr.info

--- a/src/PqResultImpl.cpp
+++ b/src/PqResultImpl.cpp
@@ -503,7 +503,8 @@ void PqResultImpl::wait_for_data() {
       // timeout reached - check user interrupt
       checkUserInterrupt();
     } else if(ret < 0) {
-      stop("select() on the connection failed");
+      stop("select() on the connection socket %d (FD_SETSIZE %d) failed with error code %d",
+           socket, FD_SETSIZE, ret);
     }
     // update db connection state using data available on the socket
     if (!PQconsumeInput(pConn_)) {

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -6,5 +6,4 @@ test_that("Query is executed properly when check_interrupts connection option is
   con <- postgresDefault(check_interrupts = TRUE)
   expect_equal(dbGetQuery(con, "SELECT pg_sleep(2), 'foo' AS x")$x, "foo")
   dbDisconnect(con)
-  expect_null(n)
 })

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -1,0 +1,10 @@
+context("checkInterrupts")
+
+test_that("Query is executed properly when check_interrupts connection option is 
+          set to TRUE and query execution takes more than check user interrupts 
+          timeout (1 second)", {
+  con <- postgresDefault(check_interrupts = TRUE)
+  expect_equal(dbGetQuery(con, "SELECT pg_sleep(2), 'foo' AS x")$x, "foo")
+  dbDisconnect(con)
+  expect_null(n)
+})

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -1,8 +1,6 @@
 context("checkInterrupts")
 
-test_that("Query is executed properly when check_interrupts connection option is 
-          set to TRUE and query execution takes more than check user interrupts 
-          timeout (1 second)", {
+test_that("check_interrupts = TRUE works with queries > 1 second (#244)", {
   con <- postgresDefault(check_interrupts = TRUE)
   expect_equal(dbGetQuery(con, "SELECT pg_sleep(2), 'foo' AS x")$x, "foo")
   dbDisconnect(con)


### PR DESCRIPTION
As reported in #244 the `check_interrupts` connection option didn't work for Windows user when a query execution took longer than 1 second.

This pull requests fixes the issue by adjusting the code to the Windows implementation of the `select()` glibc/winsock method:

* The `fd_set` structure is reinitialized with the `FD_SET` macro before each call to `select()`
* `select()` error message now includes the error code and the error code is captured in the platform-specific way (`WSAGetLastError` on Windows, `errno` global variable on other platforms)
* A unit test is added.