### PR TITLE
change docs URLs to "current" version and https

### DIFF
--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -136,21 +136,21 @@ setMethod("dbGetInfo", "PqConnection", function(dbObj, ...) {
 #'   Note that this argument can only contain the database name, it will not
 #'   be parsed as a connection string (internally, `expand_dbname` is set to
 #'   `false` in the call to
-#'   [`PQconnectdbParams()`](https://www.postgresql.org/docs/9.6/static/libpq-connect.html)).
+#'   [`PQconnectdbParams()`](https://www.postgresql.org/docs/current/libpq-connect.html)).
 #' @param user,password User name and password. If `NULL`, will be
 #'   retrieved from `PGUSER` and `PGPASSWORD` envvars, or from the
 #'   appropriate line in `~/.pgpass`. See
-#'   <http://www.postgresql.org/docs/9.6/static/libpq-pgpass.html> for
+#'   <https://www.postgresql.org/docs/current/libpq-pgpass.html> for
 #'   more details.
 #' @param host,port Host and port. If `NULL`, will be retrieved from
 #'   `PGHOST` and `PGPORT` env vars.
 #' @param service Name of service to connect as.  If `NULL`, will be
 #'   ignored.  Otherwise, connection parameters will be loaded from the pg_service.conf
-#'   file and used.  See <http://www.postgresql.org/docs/9.6/static/libpq-pgservice.html>
+#'   file and used.  See <https://www.postgresql.org/docs/current/libpq-pgservice.html>
 #'   for details on this file and syntax.
 #' @param ... Other name-value pairs that describe additional connection
 #'   options as described at
-#'   <http://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS>
+#'   <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS>
 #' @param bigint The R type that 64-bit integer types should be mapped to,
 #'   default is [bit64::integer64], which allows the full range of 64 bit
 #'   integers.

--- a/man/Postgres.Rd
+++ b/man/Postgres.Rd
@@ -33,7 +33,7 @@ to use the \pkg{RPostgres} package.}
 Note that this argument can only contain the database name, it will not
 be parsed as a connection string (internally, \code{expand_dbname} is set to
 \code{false} in the call to
-\href{https://www.postgresql.org/docs/9.6/static/libpq-connect.html}{\code{PQconnectdbParams()}}).}
+\href{https://www.postgresql.org/docs/current/libpq-connect.html}{\code{PQconnectdbParams()}}).}
 
 \item{host, port}{Host and port. If \code{NULL}, will be retrieved from
 \code{PGHOST} and \code{PGPORT} env vars.}
@@ -41,17 +41,17 @@ be parsed as a connection string (internally, \code{expand_dbname} is set to
 \item{user, password}{User name and password. If \code{NULL}, will be
 retrieved from \code{PGUSER} and \code{PGPASSWORD} envvars, or from the
 appropriate line in \verb{~/.pgpass}. See
-\url{http://www.postgresql.org/docs/9.6/static/libpq-pgpass.html} for
+\url{https://www.postgresql.org/docs/current/libpq-pgpass.html} for
 more details.}
 
 \item{service}{Name of service to connect as.  If \code{NULL}, will be
 ignored.  Otherwise, connection parameters will be loaded from the pg_service.conf
-file and used.  See \url{http://www.postgresql.org/docs/9.6/static/libpq-pgservice.html}
+file and used.  See \url{https://www.postgresql.org/docs/current/libpq-pgservice.html}
 for details on this file and syntax.}
 
 \item{...}{Other name-value pairs that describe additional connection
 options as described at
-\url{http://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
+\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
 
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:bit64-package]{bit64::integer64}, which allows the full range of 64 bit

--- a/man/Redshift.Rd
+++ b/man/Redshift.Rd
@@ -32,7 +32,7 @@ to use the \pkg{RPostgres} package.}
 Note that this argument can only contain the database name, it will not
 be parsed as a connection string (internally, \code{expand_dbname} is set to
 \code{false} in the call to
-\href{https://www.postgresql.org/docs/9.6/static/libpq-connect.html}{\code{PQconnectdbParams()}}).}
+\href{https://www.postgresql.org/docs/current/libpq-connect.html}{\code{PQconnectdbParams()}}).}
 
 \item{host}{Host and port. If \code{NULL}, will be retrieved from
 \code{PGHOST} and \code{PGPORT} env vars.}
@@ -43,23 +43,23 @@ be parsed as a connection string (internally, \code{expand_dbname} is set to
 \item{password}{User name and password. If \code{NULL}, will be
 retrieved from \code{PGUSER} and \code{PGPASSWORD} envvars, or from the
 appropriate line in \verb{~/.pgpass}. See
-\url{http://www.postgresql.org/docs/9.6/static/libpq-pgpass.html} for
+\url{https://www.postgresql.org/docs/current/libpq-pgpass.html} for
 more details.}
 
 \item{user}{User name and password. If \code{NULL}, will be
 retrieved from \code{PGUSER} and \code{PGPASSWORD} envvars, or from the
 appropriate line in \verb{~/.pgpass}. See
-\url{http://www.postgresql.org/docs/9.6/static/libpq-pgpass.html} for
+\url{https://www.postgresql.org/docs/current/libpq-pgpass.html} for
 more details.}
 
 \item{service}{Name of service to connect as.  If \code{NULL}, will be
 ignored.  Otherwise, connection parameters will be loaded from the pg_service.conf
-file and used.  See \url{http://www.postgresql.org/docs/9.6/static/libpq-pgservice.html}
+file and used.  See \url{https://www.postgresql.org/docs/current/libpq-pgservice.html}
 for details on this file and syntax.}
 
 \item{...}{Other name-value pairs that describe additional connection
 options as described at
-\url{http://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
+\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
 
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:bit64-package]{bit64::integer64}, which allows the full range of 64 bit

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -83,7 +83,7 @@ void DbConnection::reset_current_result(const DbResult* pResult) {
 
 /**
  * Documentation for canceling queries:
- * https://www.postgresql.org/docs/9.6/static/libpq-cancel.html
+ * https://www.postgresql.org/docs/current/libpq-cancel.html
  **/
 void DbConnection::cancel_query() {
   check_connection();

--- a/src/RPostgres-init.c
+++ b/src/RPostgres-init.c
@@ -4,7 +4,7 @@
 #include <windows.h>
 #endif
 
-// From http://www.postgresql.org/docs/9.4/static/libpq-connect.html:
+// From https://www.postgresql.org/docs/current/libpq-connect.html:
 // On Windows, there is a way to improve performance if a single database
 // connection is repeatedly started and shutdown. Internally, libpq calls
 // WSAStartup() and WSACleanup() for connection startup and shutdown,

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -113,7 +113,7 @@ void encode_in_buffer(RObject x, int i, std::string& buffer) {
 
 
 // Escape postgresql special characters
-// http://www.postgresql.org/docs/9.4/static/sql-copy.html#AEN71914
+// https://www.postgresql.org/docs/current/sql-copy.html
 void escape_in_buffer(const char* string, std::string& buffer) {
   size_t len = strlen(string);
 


### PR DESCRIPTION
This updates the URLs to the PostgreSQL docs to the "current" version and https scheme. 
I wasn't sure about the URLs in the cpp files. Do you want them to point at the version at the time of writing?