### PR TITLE
Fix interrupt checking

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,9 +33,12 @@ jobs:
       fail-fast: false
       # Ensure that the "cancel" workflow gets a chance to run quickly, even if we just pushed
       # Need to figure out how to smoke-test
-      max-parallel: 8
+      max-parallel: 6
       matrix:
         config:
+          - { os: macOS-latest,                 r: 'release' }
+          - { os: windows-latest,               r: 'release', rspm: "https://packagemanager.rstudio.com/all/latest" }
+          - { os: windows-latest,               r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/all/latest" }
           - { os: ubuntu-, os-version: 20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
           - { os: ubuntu-, os-version: 18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest" }
           - { os: ubuntu-, os-version: 18.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       # Ensure that the "cancel" workflow gets a chance to run quickly, even if we just pushed
       # Need to figure out how to smoke-test
-      max-parallel: 7
+      max-parallel: 8
       matrix:
         config:
           - { os: ubuntu-, os-version: 20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,12 +33,9 @@ jobs:
       fail-fast: false
       # Ensure that the "cancel" workflow gets a chance to run quickly, even if we just pushed
       # Need to figure out how to smoke-test
-      max-parallel: 6
+      max-parallel: 7
       matrix:
         config:
-          - { os: macOS-latest,                 r: 'release' }
-          - { os: windows-latest,               r: 'release', rspm: "https://packagemanager.rstudio.com/all/latest" }
-          - { os: windows-latest,               r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/all/latest" }
           - { os: ubuntu-, os-version: 20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
           - { os: ubuntu-, os-version: 18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest" }
           - { os: ubuntu-, os-version: 18.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }

--- a/src/DbConnection.h
+++ b/src/DbConnection.h
@@ -54,9 +54,9 @@ public:
   static void finish_query(PGconn* pConn);
   List wait_for_notify(int timeout_secs);
 
-private:
   void cancel_query();
 
+private:
   static void process_notice(void* This, const char* message);
 };
 

--- a/src/PqResultImpl.h
+++ b/src/PqResultImpl.h
@@ -86,7 +86,7 @@ public:
   PGresult* get_result();
 
 private:
-  void wait_for_data();
+  bool wait_for_data();
 };
 
 #endif //RPOSTGRES_PQRESULTIMPL_H

--- a/tests/testthat/_snaps/checkInterrupts.md
+++ b/tests/testthat/_snaps/checkInterrupts.md
@@ -6,25 +6,18 @@
       $code
       [1] 200
       
-      $message
-      [1] "done callr-rs-result-ac0d53be20f45"
-      
       $result
-      NULL
+      <Rcpp::exception: Failed to fetch row: ERROR:  canceling statement due to user request
+      >
       
       $stdout
       [1] ""
       
       $stderr
-      [1] "Error in mycall(sym_setout, as.integer(fd), as.logical(drop)) : \n  Cannot reroute stdout (system error 9, Bad file descriptor) @client.c:180 (processx_set_std)\nCalls: tryCatch ... tryCatchList -> tryCatchOne -> <Anonymous> -> <Anonymous>\n"
+      [1] ""
       
       $error
-      <callr_status_error: callr subprocess failed:>
-       in process 
-      -->
-      <callr_remote_error in NULL:
-       >
-       in process 704753 
+      NULL
       
       attr(,"class")
       [1] "callr_session_result"

--- a/tests/testthat/_snaps/checkInterrupts.md
+++ b/tests/testthat/_snaps/checkInterrupts.md
@@ -1,0 +1,31 @@
+# check_interrupts = TRUE interrupts immediately (#336)
+
+    Code
+      out
+    Output
+      $code
+      [1] 200
+      
+      $message
+      [1] "done callr-rs-result-ac0d53be20f45"
+      
+      $result
+      NULL
+      
+      $stdout
+      [1] ""
+      
+      $stderr
+      [1] "Error in mycall(sym_setout, as.integer(fd), as.logical(drop)) : \n  Cannot reroute stdout (system error 9, Bad file descriptor) @client.c:180 (processx_set_std)\nCalls: tryCatch ... tryCatchList -> tryCatchOne -> <Anonymous> -> <Anonymous>\n"
+      
+      $error
+      <callr_status_error: callr subprocess failed:>
+       in process 
+      -->
+      <callr_remote_error in NULL:
+       >
+       in process 704753 
+      
+      attr(,"class")
+      [1] "callr_session_result"
+

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -7,6 +7,8 @@ test_that("check_interrupts = TRUE works with queries > 1 second (#244)", {
 })
 
 test_that("check_interrupts = TRUE interrupts immediately (#336)", {
+  skip_if(Sys.getenv("R_COVR") != "")
+
   # For skipping if not available
   dbDisconnect(postgresDefault())
 

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -25,12 +25,12 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
     )
   })
 
-  session$poll_process(200)
+  session$poll_process(300)
   expect_null(session$read())
 
   session$interrupt()
 
-  # Should take much less than 1.9 seconds
+  # Should take much less than 1.7 seconds
   time <- system.time(
     expect_equal(session$poll_process(2000), "ready")
   )

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -36,7 +36,12 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
   )
   expect_lt(time[["elapsed"]], 1)
 
+  local_edition(3)
+
   # Should return a proper error message
   out <- session$read()
-  expect_match(out$result$message, "cancel")
+
+  expect_snapshot({
+    out
+  })
 })

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -5,3 +5,35 @@ test_that("check_interrupts = TRUE works with queries > 1 second (#244)", {
   expect_equal(dbGetQuery(con, "SELECT pg_sleep(2), 'foo' AS x")$x, "foo")
   dbDisconnect(con)
 })
+
+test_that("check_interrupts = TRUE interrupts immediately (#336)", {
+  session <- callr::r_session$new()
+
+  session$run(function() {
+    library(RPostgres)
+    .GlobalEnv$conn <- dbConnect(Postgres(), check_interrupts = TRUE)
+    invisible()
+  })
+
+  session$call(function() {
+    tryCatch(
+      print(dbGetQuery(.GlobalEnv$conn, "SELECT pg_sleep(2)")),
+      error = identity
+    )
+  })
+
+  session$poll_process(100)
+  expect_null(session$read())
+
+  session$interrupt()
+
+  # Should take much less than 1.9 seconds
+  time <- system.time(
+    expect_equal(session$poll_process(2000), "ready")
+  )
+  expect_lt(time[["elapsed"]], 1)
+
+  # Should return a proper error message
+  out <- session$read()
+  expect_match(out$result$message, "cancel")
+})

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -12,6 +12,8 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
 
   session <- callr::r_session$new()
 
+  session$supervise(TRUE)
+
   session$run(function() {
     library(RPostgres)
     .GlobalEnv$conn <- postgresDefault(check_interrupts = TRUE)
@@ -46,4 +48,6 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
   expect_snapshot({
     out
   })
+
+  session$close()
 })

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -41,6 +41,7 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
   # Should return a proper error message
   out <- session$read()
   out$message <- NULL
+  out$stderr <- gsub("\r\n", "", out$stderr)
 
   expect_snapshot({
     out

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -8,6 +8,7 @@ test_that("check_interrupts = TRUE works with queries > 1 second (#244)", {
 
 test_that("check_interrupts = TRUE interrupts immediately (#336)", {
   skip_if(Sys.getenv("R_COVR") != "")
+  skip_if(getRversion() >= "3.6" && getRversion() < "4.0")
 
   # For skipping if not available
   dbDisconnect(postgresDefault())

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -25,7 +25,7 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
     )
   })
 
-  session$poll_process(100)
+  session$poll_process(200)
   expect_null(session$read())
 
   session$interrupt()

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -7,11 +7,14 @@ test_that("check_interrupts = TRUE works with queries > 1 second (#244)", {
 })
 
 test_that("check_interrupts = TRUE interrupts immediately (#336)", {
+  # For skipping if not available
+  dbDisconnect(postgresDefault())
+
   session <- callr::r_session$new()
 
   session$run(function() {
     library(RPostgres)
-    .GlobalEnv$conn <- dbConnect(Postgres(), check_interrupts = TRUE)
+    .GlobalEnv$conn <- postgresDefault(check_interrupts = TRUE)
     invisible()
   })
 

--- a/tests/testthat/test-checkInterrupts.R
+++ b/tests/testthat/test-checkInterrupts.R
@@ -40,6 +40,7 @@ test_that("check_interrupts = TRUE interrupts immediately (#336)", {
 
   # Should return a proper error message
   out <- session$read()
+  out$message <- NULL
 
   expect_snapshot({
     out


### PR DESCRIPTION
Closes #336.

``` r
session <- callr::r_session$new()

session$run(function() {
  library(RPostgres)
  .GlobalEnv$conn <- dbConnect(Postgres(), check_interrupts = TRUE)
  invisible()
})
#> NULL
session$call(function() {
  tryCatch(
    print(dbGetQuery(.GlobalEnv$conn, "SELECT pg_sleep(2)")),
    error = identity
  )
})

session$poll_process(100)
#> [1] "timeout"
session$read()
#> NULL
session$interrupt()
#> [1] TRUE
# Should take much less than 1.9 seconds
time <- system.time(session$poll_process(2000))
print(time)
#>    user  system elapsed 
#>   0.000   0.000   0.001
# Should return a proper error message
out <- session$read()
out
#> $code
#> [1] 200
#> 
#> $message
#> [1] "done callr-rs-result-106b8135f5fa5"
#> 
#> $result
#> <Rcpp::exception: Failed to fetch row: ERROR:  canceling statement due to user request
#> >
#> 
#> $stdout
#> [1] ""
#> 
#> $stderr
#> [1] ""
#> 
#> $error
#> NULL
#> 
#> attr(,"class")
#> [1] "callr_session_result"
```

<sup>Created on 2021-09-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>