### PR TITLE
Handling table path as character

### DIFF
--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -12,7 +12,8 @@ setClass("PqConnection",
     bigint = "character",
     timezone = "character",
     timezone_out = "character",
-    typnames = "data.frame"
+    typnames = "data.frame",
+    unquote_id = "logical"
   )
 )
 
@@ -164,6 +165,8 @@ setMethod("dbGetInfo", "PqConnection", function(dbObj, ...) {
 #'   set to [Sys.timezone()] or `""`.
 #'   This setting does not change the time values returned, only their display.
 #' @param conn Connection to disconnect.
+#' @param unquote_id Should driver unquote character automatically (before
+#'   quote the character)? Setting to `TRUE` convert character to Identifier before quote.
 #' @export
 #' @rdname Postgres
 #' @examplesIf postgresHasDefault()
@@ -175,7 +178,7 @@ setMethod("dbConnect", "PqDriver",
   function(drv, dbname = NULL,
            host = NULL, port = NULL, password = NULL, user = NULL, service = NULL, ...,
            bigint = c("integer64", "integer", "numeric", "character"),
-           check_interrupts = FALSE, timezone = "UTC", timezone_out = NULL) {
+           check_interrupts = FALSE, timezone = "UTC", timezone_out = NULL, unquote_id = FALSE) {
 
     opts <- unlist(list(dbname = dbname, user = user, password = password,
       host = host, port = as.character(port), service = service, client_encoding = "utf8", ...))
@@ -199,7 +202,7 @@ setMethod("dbConnect", "PqDriver",
 
     # timezone is set later
     conn <- new("PqConnection",
-      ptr = ptr, bigint = bigint, timezone = character(), typnames = data.frame()
+      ptr = ptr, bigint = bigint, timezone = character(), typnames = data.frame(), unquote_id = unquote_id
     )
     on.exit(dbDisconnect(conn))
 

--- a/R/Redshift.R
+++ b/R/Redshift.R
@@ -24,7 +24,7 @@ setMethod("dbConnect", "RedshiftDriver",
   function(drv, dbname = NULL,
            host = NULL, port = NULL, password = NULL, user = NULL, service = NULL, ...,
            bigint = c("integer64", "integer", "numeric", "character"),
-           check_interrupts = FALSE, timezone = "UTC") {
+           check_interrupts = FALSE, timezone = "UTC", unquote_id = FALSE) {
 
     new("RedshiftConnection", callNextMethod())
   }


### PR DESCRIPTION
**Case**:
```
dbWriteTable(con, "private_schema.iris", iris)
```

Less experienced users may use the above code to write the table to `"private"` schema.
This will in fact write table named `private.schema.iris` to `"public"` schema, which may result with accidental leak of data. It also simplify usability for this group of users. 

**Issue**:
`dbQuoteIdentifier`  is not handling full table identifier as character .

**Example**:
Execution of `dbWriteTable(con, "private_schema.iris", iris)` will save the table to `"current_schema"."private_schema.iris"`.


This PR is a proposition to add an option to unquote the identifier while calling `dbQuoteIdentifier`.

It simply allows read/write methods from/to `"private_schema"."iris"`.

**Description**:
- `unquote_id` the parameter that can enable the feature (specified while setting up the connection) - setting to `TRUE` converts character to the identifier before being quoted.

Because `dbQuoteIdentifier` doesn't store the information about type of the data (schema, table, fields) I've had to detect it with the usage of `match.call`: `!grepl("names\\((.*?)\\)", as.character(match.call())[[3]])`.
This allows to handle cases where table fields contain `.` character in names.
