### PR TITLE
chore: refactor `dbListTables()` et al.

### DIFF
--- a/R/dbExistsTable_PqConnection_character.R
+++ b/R/dbExistsTable_PqConnection_character.R
@@ -2,10 +2,11 @@
 #' @usage NULL
 dbExistsTable_PqConnection_character <- function(conn, name, ...) {
   stopifnot(length(name) == 1L)
-  name <- dbQuoteIdentifier(conn, name)
-
-  # Convert to identifier
-  id <- dbUnquoteIdentifier(conn, name)[[1]]
+  # use (Un)QuoteIdentifier roundtrip instead of Id(table = name)
+  # so that quoted names (possibly incl. schema) can be passed to `name` e.g.
+  # name = dbQuoteIdentifier(conn, Id(schema = "sname", table = "tname"))
+  quoted <- dbQuoteIdentifier(conn, name)
+  id <- dbUnquoteIdentifier(conn, quoted)[[1]]
   exists_table(conn, id)
 }
 

--- a/R/dbListFields_PqConnection_Id.R
+++ b/R/dbListFields_PqConnection_Id.R
@@ -1,7 +1,7 @@
 #' @rdname postgres-tables
 #' @usage NULL
 dbListFields_PqConnection_Id <- function(conn, name, ...) {
-  list_fields(conn, name)
+  list_fields(conn, id = name)
 }
 
 #' @rdname postgres-tables

--- a/R/dbListTables_PqConnection.R
+++ b/R/dbListTables_PqConnection.R
@@ -1,12 +1,9 @@
 #' @rdname postgres-tables
 #' @usage NULL
 dbListTables_PqConnection <- function(conn, ...) {
-  query <- paste0(
-    "SELECT table_name FROM INFORMATION_SCHEMA.tables ",
-    "WHERE ",
-    "(table_schema = ANY(current_schemas(true))) AND (table_schema <> 'pg_catalog')"
-  )
-  dbGetQuery(conn, query)[[1]]
+  query <- list_tables(conn = conn, order_by = "table_type, table_name")
+
+  dbGetQuery(conn, query)[["table_name"]]
 }
 
 #' @rdname postgres-tables


### PR DESCRIPTION
I would like to take another stab at #251 and this some preparatory work for that.

# Background

Materialized views are currently not returned by `dbListTables()` et al (#251). Materialized Views are not included in `INFORMATION_SCHEMA.tables` (see [this thread](https://www.postgresql.org/message-id/flat/CAH7T-ao6ece1mgCsCvsE04W59ZZJP9gGXVK97wkUzRV5gsDqQQ%40mail.gmail.com) for why they are not. Tl;dr: "They are not defined by the SQL standard.")

> The information schema consists of a set of views that contain information about the objects defined in the current database. 
> The information schema is defined in the SQL standard and can therefore be expected to be portable and remain stable — unlike the system catalogs, which are specific to PostgreSQL and are modeled after implementation concerns. 
> The information schema views do not, however, contain information about PostgreSQL-specific features; to __inquire about those you need to query the system catalogs__ or other PostgreSQL-specific views.
> https://www.postgresql.org/docs/current/information-schema.html (emphasis mine).

Sidenote: Most if not all tables in information_schema are just views of the system catalogs, see e.g. 

```
SELECT definition FROM pg_views 
WHERE schemaname = 'information_schema' AND viewname = 'tables';
```

Since mviews are PostgreSQL-specific features we need to query the system catalogs. In particular, we need to use [`pg_class`](https://www.postgresql.org/docs/current/catalog-pg-class.html)/[`pg_namespace`](https://www.postgresql.org/docs/current/catalog-pg-namespace.html) instead of `INFORMATION_SCHEMA.tables`. 

However, in order to retain support for Redshift, we need to keep the `INFORMATION_SCHEMA` queries as well.

# What happens in this PR?

The above affects the queries that underly the `dbListTables()`, `dbExistsTable()`, `dbListObjects()`, and `dbListFields()` functions.  

`dbListTables()`, `dbExistsTable()` and `dbListObjects()` do essentially the same thing, namely call `INFORMATION_SCHEMA.tables`. 
In order to make the abovementioned adjustments easier and keep duplicated code at a minimum, I refactored those functions to use a common core function `list_tables()`, which returns the SQL code to query `INFORMATION_SCHEMA.tables`. The (alternative) queries to `pg_class` (to be added in another PR) will then live here.

I refactored the `find_table()` and `list_fields()` functions that underly `dbListFields()` in a similar fashion. 

<details>
<summary>Details</summary>

`dbListFields()`: find the first table on the search path

```sql
SELECT column_name FROM (
  SELECT *, rank() OVER (ORDER BY nr) AS rnr FROM (
    SELECT nr, schemas[nr] AS table_schema FROM (
      SELECT *, generate_subscripts(schemas, 1) AS nr FROM (
        SELECT current_schemas(true) AS schemas) t
      ) tt WHERE schemas[nr] <> 'pg_catalog'
    ) ttt 
  INNER JOIN INFORMATION_SCHEMA.columns USING (table_schema) WHERE table_name = [table_name]
) tttt 
WHERE rnr = 1 ORDER BY ordinal_position
```

can be re-written as (with 2 instead of 4 nested queries)

```sql
SELECT column_name FROM (
  SELECT *, rank() OVER (ORDER BY schema_nr) AS schema_rank FROM (
    SELECT * FROM unnest(current_schemas(true)) WITH ORDINALITY AS "tbl"("table_schema","schema_nr") 
    WHERE "table_schema" != 'pg_catalog') t 
  INNER JOIN INFORMATION_SCHEMA.columns USING (table_schema) 
  WHERE table_name = [table_name]) tt 
WHERE schema_rank = 1 
ORDER BY ordinal_position
```

</details>

Essentially I applied similar query code here as in #261, but calling `information_schema` instead of the system catalogs.
I will open another PR to incorporate the queries to the system catalogs.

It is probably easiest to review this by going through the individual commits.

I do not have access to Redshift, so I was not able to test this PR there. There might be small adjustments necessary (see below). Is it somehow possible for me to test on Redshift (e.g. via GHA)? Or how does this work in general?

# Related issues

https://github.com/r-dbi/RPostgres/issues/251
https://github.com/r-dbi/RPostgres/pull/261

This does not address #388. I think it is best to address this after #251 is resolved.

#390 is also related, but relatively trivial to apply before or after this.