### PR TITLE
Fix warnings sprintf

### DIFF
--- a/src/vendor/boost/lexical_cast/detail/converter_lexical_streams.hpp
+++ b/src/vendor/boost/lexical_cast/detail/converter_lexical_streams.hpp
@@ -279,11 +279,7 @@ namespace boost {
                 using namespace std;
                 const double val_as_double = val;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<float>()), val_as_double);
                 return finish > start;
             }
@@ -291,11 +287,7 @@ namespace boost {
             bool shl_real_type(double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
                     "%.*g", static_cast<int>(boost::detail::lcast_get_precision<double>()), val);
                 return finish > start;
             }
@@ -304,11 +296,7 @@ namespace boost {
             bool shl_real_type(long double val, char* begin) {
                 using namespace std;
                 finish = start +
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(__SGI_STL_PORT) && !defined(_STLPORT_VERSION)
                     sprintf_s(begin, CharacterBufferSize,
-#else
-                    sprintf(begin, 
-#endif
                     "%.*Lg", static_cast<int>(boost::detail::lcast_get_precision<long double>()), val );
                 return finish > start;
             }

--- a/src/vendor/boost/mpl/assert.hpp
+++ b/src/vendor/boost/mpl/assert.hpp
@@ -190,6 +190,12 @@ template< typename P > struct assert_arg_pred_not
 //#pragma GCC diagnostic ignored "-Wparentheses"
 #endif
 
+#if defined(BOOST_GCC) && BOOST_GCC >= 80000
+#define BOOST_MPL_IGNORE_PARENTHESES_WARNING
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
+#endif
+
 template< typename Pred >
 failed ************ (Pred::************
       assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type )


### PR DESCRIPTION
- remove `sprintf` from boost version without buffer size argument
- fix boost warning related to `assert` - https://github.com/boostorg/mpl/pull/34