### PR TITLE
fix: Use `NULL` in favor of `NULL::text` when quoting strings and literals, to support JSON and other text-ish types. Fixes a regression introduced in #370

### DIFF
--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -243,7 +243,7 @@ SEXP DbConnection::quote_identifier(const cpp11::r_string& x) {
 }
 
 SEXP DbConnection::get_null_string() {
-  static cpp11::sexp null = Rf_mkCharCE("NULL::text", CE_UTF8);
+  static cpp11::sexp null = Rf_mkCharCE("NULL", CE_UTF8);
   return null;
 }
 


### PR DESCRIPTION
Closes #393.