### PR TITLE
fix: `dbWriteTable()` correctly handles name clashes between temporary and permanent tables

### DIFF
--- a/R/dbWriteTable_PqConnection_character_data.frame.R
+++ b/R/dbWriteTable_PqConnection_character_data.frame.R
@@ -44,20 +44,19 @@ dbWriteTable_PqConnection_character_data.frame <- function(conn, name, value, ..
     })
   }
 
-  found <- dbExistsTable(conn, name)
-  if (found && !overwrite && !append) {
-    stop("Table ", name, " exists in database, and both overwrite and",
-      " append are FALSE",
-      call. = FALSE
-    )
-  }
-  if (found && overwrite) {
-    dbRemoveTable(conn, name)
+  if (overwrite) {
+    suppressMessages(dbRemoveTable(conn, name, temporary = temporary, fail_if_missing = FALSE))
+    found <- FALSE
+  } else {
+    found <- dbExistsTable(conn, name)
+    if (found && !append) {
+      stopc("Table ", name, " exists in database, and both overwrite and append are FALSE")
+    }
   }
 
   value <- sqlRownamesToColumn(value, row.names)
 
-  if (!found || overwrite) {
+  if (!found) {
     if (is.null(field.types)) {
       combined_field_types <- lapply(value, dbDataType, dbObj = conn)
     } else {

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -146,6 +146,25 @@ if (postgresHasDefault()) {
         })
       })
     })
+
+
+    describe("Name clashes", {
+      test_that("Can write to temporary table if permanent table exists (#402)", {
+        skip_on_cran()
+
+        dbWriteTable(con, "my_name_clash", data.frame(a = 1), overwrite = TRUE)
+        expect_equal(dbReadTable(con, "my_name_clash"), data.frame(a = 1))
+
+        dbWriteTable(con, "my_name_clash", data.frame(b = 2), overwrite = TRUE, temporary = TRUE)
+        expect_equal(dbReadTable(con, "my_name_clash"), data.frame(b = 2))
+
+        dbRemoveTable(con, "my_name_clash", temporary = TRUE)
+        expect_equal(dbReadTable(con, "my_name_clash"), data.frame(a = 1))
+
+        dbRemoveTable(con, "my_name_clash")
+        dbDisconnect(con)
+      })
+    })
   })
 
 }


### PR DESCRIPTION
Closes #402.