### PR TITLE
chore: tweak driver docs

### DIFF
--- a/R/Redshift.R
+++ b/R/Redshift.R
@@ -1,6 +1,6 @@
 #' Redshift driver/connection
 #'
-#' Use `Redshift()` instead of `Postgres()` to connect to an AWS Redshift cluster.
+#' Use `drv = Redshift()` instead of `drv = Postgres()` to connect to an AWS Redshift cluster.
 #' All methods in \pkg{RPostgres} and downstream packages can be called on such connections.
 #' Some have different behavior for Redshift connections, to ensure better interoperability.
 #'

--- a/R/dbConnect_PqDriver.R
+++ b/R/dbConnect_PqDriver.R
@@ -6,16 +6,18 @@
 #'
 #' @description
 #' `DBI::dbConnect()` establishes a connection to a database.
-#' Set `drv = RPostgres::Postgres()` to connect to a SQL database
-#' using the \pkg{RPostgres} package.
+#' Set `drv = Postgres()` to connect to a PostgreSQL(-ish) database. Use `drv =
+#' Redshift()` instead to connect to an AWS Redshift cluster.
 #'
 #' Manually disconnecting a connection is not necessary with \pkg{RPostgres},
 #' but still recommended;
 #' if you delete the object containing the connection, it will be automatically
 #' disconnected during the next GC with a warning.
 #'
-#' @param drv Should be set to [RPostgres::Postgres()]
-#'   to use the \pkg{RPostgres} package.
+#' @param drv [DBI::DBIDriver-class]. Use [Postgres()] to connect to a
+#'   PostgreSQL(-ish) database or [Redshift()] to connect to an AWS Redshift
+#'   cluster. Use an existing [DBI::DBIConnection-class] object to clone an
+#'   existing connection.
 #' @param dbname Database name. If `NULL`, defaults to the user name.
 #'   Note that this argument can only contain the database name, it will not
 #'   be parsed as a connection string (internally, `expand_dbname` is set to

--- a/man/Postgres.Rd
+++ b/man/Postgres.Rd
@@ -29,8 +29,10 @@ Postgres()
 \S4method{dbDisconnect}{PqConnection}(conn, ...)
 }
 \arguments{
-\item{drv}{Should be set to \code{\link[=Postgres]{Postgres()}}
-to use the \pkg{RPostgres} package.}
+\item{drv}{\link[DBI:DBIDriver-class]{DBI::DBIDriver}. Use \code{\link[=Postgres]{Postgres()}} to connect to a
+PostgreSQL(-ish) database or \code{\link[=Redshift]{Redshift()}} to connect to an AWS Redshift
+cluster. Use an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection} object to clone an
+existing connection.}
 
 \item{dbname}{Database name. If \code{NULL}, defaults to the user name.
 Note that this argument can only contain the database name, it will not
@@ -76,8 +78,7 @@ This setting does not change the time values returned, only their display.}
 }
 \description{
 \code{DBI::dbConnect()} establishes a connection to a database.
-Set \code{drv = RPostgres::Postgres()} to connect to a SQL database
-using the \pkg{RPostgres} package.
+Set \code{drv = Postgres()} to connect to a PostgreSQL(-ish) database. Use \code{drv = Redshift()} instead to connect to an AWS Redshift cluster.
 
 Manually disconnecting a connection is not necessary with \pkg{RPostgres},
 but still recommended;

--- a/man/Redshift.Rd
+++ b/man/Redshift.Rd
@@ -26,8 +26,10 @@ Redshift()
 )
 }
 \arguments{
-\item{drv}{Should be set to \code{\link[=Postgres]{Postgres()}}
-to use the \pkg{RPostgres} package.}
+\item{drv}{\link[DBI:DBIDriver-class]{DBI::DBIDriver}. Use \code{\link[=Postgres]{Postgres()}} to connect to a
+PostgreSQL(-ish) database or \code{\link[=Redshift]{Redshift()}} to connect to an AWS Redshift
+cluster. Use an existing \link[DBI:DBIConnection-class]{DBI::DBIConnection} object to clone an
+existing connection.}
 
 \item{dbname}{Database name. If \code{NULL}, defaults to the user name.
 Note that this argument can only contain the database name, it will not
@@ -65,7 +67,7 @@ running too long.}
 If \code{NULL} then no timezone is set, which defaults to the server's time zone.}
 }
 \description{
-Use \code{Redshift()} instead of \code{Postgres()} to connect to an AWS Redshift cluster.
+Use \code{drv = Redshift()} instead of \code{drv = Postgres()} to connect to an AWS Redshift cluster.
 All methods in \pkg{RPostgres} and downstream packages can be called on such connections.
 Some have different behavior for Redshift connections, to ensure better interoperability.
 }


### PR DESCRIPTION
This tweaks the `drv` docs a little to make it clearer that there are two alternatives and when to use which.

Motivation: "drv: Should be set to [RPostgres::Postgres()] to use the \pkg{RPostgres} package." does not sound correct anymore.