### PR TITLE
feat: `dbQuoteLiteral()` correctly quotes 64-bit integers from the bit64 package (of class `"integer64"`)

### DIFF
--- a/R/dbQuoteLiteral_PqConnection.R
+++ b/R/dbQuoteLiteral_PqConnection.R
@@ -22,6 +22,10 @@ dbQuoteLiteral_PqConnection <- function(conn, x, ...) {
     ret <- paste0("'", as.character(hms::as_hms(x)), "'")
     ret[is.na(x)] <- "NULL"
     SQL(paste0(ret, "::interval"), names = names(ret))
+  } else if (inherits(x, "integer64")) {
+    ret <- as.character(x)
+    ret[is.na(x)] <- "NULL"
+    SQL(paste0(ret, "::int8"), names = names(ret))
   } else if (is.logical(x)) {
     ret <- as.character(x)
     ret[is.na(ret)] <- "NULL::bool"

--- a/tests/testthat/test-dbQuoteLiteral.R
+++ b/tests/testthat/test-dbQuoteLiteral.R
@@ -1,0 +1,10 @@
+test_that("integer64 values are treated as bigints, not floats", {
+  con <- postgresDefault()
+
+  x <- structure(4.94065645841247e-324, class = "integer64")
+
+  expect_equal(
+    as.character(dbQuoteLiteral(con, x)),
+    "1::int8"
+  )
+})

--- a/tests/testthat/test-dbQuoteLiteral.R
+++ b/tests/testthat/test-dbQuoteLiteral.R
@@ -1,5 +1,6 @@
 test_that("integer64 values are treated as bigints, not floats", {
   con <- postgresDefault()
+  on.exit(dbDisconnect(con))
 
   x <- structure(4.94065645841247e-324, class = "integer64")
 


### PR DESCRIPTION
Fixes #435 by adding a branch of logic to `dbQuoteLiteral_PqConnection` that checks if the value is integer64, and if so appending `::int8`. 