### PR TITLE
chore: Suppress warning in gcc-12

### DIFF
--- a/src/pch.h
+++ b/src/pch.h
@@ -2,3 +2,10 @@
 #include <libpq-fe.h>
 
 #include <plogr.h>
+
+// Temporary fix for false positive in gcc-12 (fixed in gcc-13)
+#if __GNUC__ == 12
+/*IGNORE*/ #pragma GCC diagnostic push
+/*IGNORE*/ #pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
+


### PR DESCRIPTION
There is bug in gcc-12 that leads to the warning:

```
warning: pointer used after 'void operator delete(void*, std::size_t)' [-Wuse-after-free]
```

The bug is fixed in gcc-13. So we suppress it. 