### PR TITLE
Bump preferred libpq version on MacOS to 15

### DIFF
--- a/configure
+++ b/configure
@@ -19,7 +19,7 @@ PKG_LIBS="-lpq"
 # Extra checks on MacOS for SSL support in libpq
 # command -v is probably fine: https://stackoverflow.com/a/677212/946850
 if [ "`uname`" = Darwin ] && [ "`command -v pkg-config`" ]; then
-  if pkg-config --atleast-version=12 libpq; then
+  if pkg-config --atleast-version=15 libpq; then
     case "`pkg-config --libs --static libpq`" in
     *crypto*)
       echo "Local libpq has SSL support"


### PR DESCRIPTION
Fall back on autobrew if the local macos libpq is out of date. Fixes #441.