### PR TITLE
fledge: CRAN pre-release v1.4.7.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RPostgres
 Title: C++ Interface to PostgreSQL
-Version: 1.4.7.9020
+Version: 1.4.7.9900
 Date: 2025-02-24
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RPostgres 1.4.7.9020 (2025-02-24)
+# RPostgres 1.4.7.9900 (2025-02-24)
+
+## Windows
+
+- Update libpq fallback library (#489).
+
+- Use libpq from Rtools if available (#486).
 
 ## Features
 
@@ -10,169 +16,63 @@
 
 - IDE.
 
+- Auto-update from GitHub Actions.
 
-# RPostgres 1.4.7.9019 (2025-02-20)
+  Run: https://github.com/r-dbi/RPostgres/actions/runs/10425486593
 
-## Windows
+  Run: https://github.com/r-dbi/RPostgres/actions/runs/10224248168
 
-- Update libpq fallback library (#489).
+  Run: https://github.com/r-dbi/RPostgres/actions/runs/10200112323
 
+  Run: https://github.com/r-dbi/RPostgres/actions/runs/9728443553
 
-# RPostgres 1.4.7.9018 (2025-02-09)
+  Run: https://github.com/r-dbi/RPostgres/actions/runs/9692464325
 
 ## Continuous integration
 
 - Test on older Windows versions.
 
-
-# RPostgres 1.4.7.9017 (2025-02-08)
-
-## Windows
-
-- Use libpq from Rtools if available (#486).
-
-
-# RPostgres 1.4.7.9016 (2024-12-12)
-
-## Continuous integration
-
 - Avoid failure in fledge workflow if no changes (#479).
 
 - Remove Aviator.
 
-
-# RPostgres 1.4.7.9015 (2024-12-08)
-
-## Continuous integration
-
 - Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#478).
-
-
-# RPostgres 1.4.7.9014 (2024-12-07)
-
-## Continuous integration
 
 - Use stable pak (#477).
 
+- Latest changes (#475).
 
-# RPostgres 1.4.7.9013 (2024-11-10)
+- Import from actions-sync, check carefully (#474).
 
-## Continuous integration
+- Use pkgdown branch (#473).
 
-  - Latest changes (#475).
+  - ci: Use pkgdown branch
 
+  - ci: Updates from duckdb
 
-# RPostgres 1.4.7.9012 (2024-10-28)
+  - ci: Trigger run
 
-## Continuous integration
+- Install via R CMD INSTALL ., not pak (#471).
 
-  - Import from actions-sync, check carefully (#474).
+  - ci: Install via R CMD INSTALL ., not pak
 
-  - Use pkgdown branch (#473).
-    
-      - ci: Use pkgdown branch
-    
-      - ci: Updates from duckdb
-    
-      - ci: Trigger run
+  - ci: Bump version of upload-artifact action
 
+- Install local package for pkgdown builds.
 
-# RPostgres 1.4.7.9011 (2024-09-15)
+- Improve support for protected branches with fledge.
 
-## Continuous integration
-
-  - Install via R CMD INSTALL ., not pak (#471).
-    
-      - ci: Install via R CMD INSTALL ., not pak
-    
-      - ci: Bump version of upload-artifact action
-
-
-# RPostgres 1.4.7.9010 (2024-08-31)
-
-## Continuous integration
-
-  - Install local package for pkgdown builds.
-
-  - Improve support for protected branches with fledge.
-
-  - Improve support for protected branches, without fledge.
-
-
-# RPostgres 1.4.7.9009 (2024-08-17)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10425486593
-
-## Continuous integration
+- Improve support for protected branches, without fledge.
 
 - Sync with latest developments.
 
-
-# RPostgres 1.4.7.9008 (2024-08-10)
-
-## Continuous integration
-
 - Use v2 instead of master.
-
-
-# RPostgres 1.4.7.9007 (2024-08-06)
-
-## Continuous integration
 
 - Inline action.
 
-
-# RPostgres 1.4.7.9006 (2024-08-03)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10224248168
-
-
-# RPostgres 1.4.7.9005 (2024-08-02)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10200112323
-
-## Continuous integration
-
 - Use dev roxygen2 and decor.
 
-
-# RPostgres 1.4.7.9004 (2024-07-02)
-
-## Continuous integration
-
 - Fix on Windows, tweak lock workflow.
-
-
-# RPostgres 1.4.7.9003 (2024-07-01)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/9728443553
-
-
-# RPostgres 1.4.7.9002 (2024-06-28)
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/9692464325
-
-## Continuous integration
 
 - Avoid checking bashisms on Windows.
 
@@ -184,13 +84,7 @@
 
 - Recent updates.
 
-
-# RPostgres 1.4.7.9001 (2024-06-03)
-
-- Merge branch 'cran-1.4.7'.
-
-
-# RPostgres 1.4.7.9000 (2024-05-26)
+## Uncategorized
 
 - Merge branch 'cran-1.4.7'.
 

--- a/R/PqConnection.R
+++ b/R/PqConnection.R
@@ -151,7 +151,7 @@ postgresIsTransacting <- function(conn) {
 #' \dontrun{
 #' con <- postgresDefault()
 #' filepath <- 'your_image.png'
-#' dbWithTransaction(con, { 
+#' dbWithTransaction(con, {
 #'   oid <- postgresImportLargeObject(con, filepath)
 #' })
 #' }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,22 +1,5 @@
-Resubmission.
+RPostgres 1.4.7.9900
 
-RPostgres 1.4.7
+## Cran Repository Policy
 
-## R CMD check results
-
-- [x] Checked locally, R 4.3.3
-- [x] Checked on CI system, R 4.4.0
-- [x] Checked on win-builder, R devel
-
-## Current CRAN check results
-
-- [x] Checked on 2024-05-26, problems found: https://cran.r-project.org/web/checks/check_results_RPostgres.html
-- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-devel-windows-x86_64
-     File ‘RPostgres/libs/RPostgres.so’:
-     Found non-API calls to R: ‘SETLENGTH’, ‘SET_TRUELENGTH’
-     
-     Compiled code should not call non-API entry points in R.
-     
-     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
-     
-     Upstream problem, can't fix.
+- [x] Reviewed CRP last edited 2024-08-27.

--- a/man/postgresImportLargeObject.Rd
+++ b/man/postgresImportLargeObject.Rd
@@ -22,10 +22,10 @@ Returns an object idenfier (Oid) for the imported large object
 }
 \examples{
 \dontrun{
-con       <- postgresDefault()
+con <- postgresDefault()
 filepath <- 'your_image.png'
-dbWithTransaction(con, { 
- oid <- postgresImportLargeObject(con, filepath)
+dbWithTransaction(con, {
+  oid <- postgresImportLargeObject(con, filepath)
 })
 }
 }

--- a/tests/testthat/test-ImportLargeObject.R
+++ b/tests/testthat/test-ImportLargeObject.R
@@ -2,10 +2,12 @@
 test_that("can import and read a large object", {
   con       <- postgresDefault()
   on.exit(dbDisconnect(con))
-  test_file_path <- paste0(test_path(),'/data/large_object.txt')
-  dbWithTransaction(con, { oid <- postgresImportLargeObject(con, test_file_path) })
-  expect_gt(oid,0)
-  lo_data           <- unlist(dbGetQuery(con, "select lo_get($1) as lo_data", params=list(oid))$lo_data[1])
+  test_file_path <- paste0(test_path(), '/data/large_object.txt')
+  dbWithTransaction(con, {
+    oid <- postgresImportLargeObject(con, test_file_path)
+  })
+  expect_gt(oid, 0)
+  lo_data           <- unlist(dbGetQuery(con, "select lo_get($1) as lo_data", params = list(oid))$lo_data[1])
   large_object_txt  <- as.raw(c(0x70, 0x6f, 0x73, 0x74, 0x67, 0x72, 0x65, 0x73)) # the string 'postgres'
   expect_equal(lo_data, large_object_txt)
 })
@@ -14,24 +16,28 @@ test_that("can import and read a large object", {
 test_that("importing to an existing oid throws error", {
   con       <- postgresDefault()
   on.exit(dbDisconnect(con))
-  test_file_path <- paste0(test_path(),'/data/large_object.txt')
+  test_file_path <- paste0(test_path(), '/data/large_object.txt')
   oid <- 1234
-  dbWithTransaction(con, { oid <- postgresImportLargeObject(con, test_file_path, oid) })
+  dbWithTransaction(con, {
+    oid <- postgresImportLargeObject(con, test_file_path, oid)
+  })
 
   expect_error(
-    dbWithTransaction(con, { oid <- postgresImportLargeObject(con, test_file_path, oid) })
+    dbWithTransaction(con, {
+      oid <- postgresImportLargeObject(con, test_file_path, oid)
+    })
   )
-  dbExecute(con, "select lo_unlink($1) as lo_data", params=list(oid))
+  dbExecute(con, "select lo_unlink($1) as lo_data", params = list(oid))
 })
 
 
 test_that("import from a non-existing path throws error", {
   con       <- postgresDefault()
   on.exit(dbDisconnect(con))
-  test_file_path <- paste0(test_path(),'/data/large_object_that_does_not_exist.txt')
-  expect_error( 
-    dbWithTransaction(con, { oid <- postgresImportLargeObject(con, test_file_path) })
+  test_file_path <- paste0(test_path(), '/data/large_object_that_does_not_exist.txt')
+  expect_error(
+    dbWithTransaction(con, {
+      oid <- postgresImportLargeObject(con, test_file_path)
+    })
   )
 })
-
-


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-02-24, problems found: https://cran.r-project.org/web/checks/check_results_RPostgres.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     postgres-query.Rd: dbConnect, dbGetRowsAffected
     postgres-tables.Rd: dbAppendTable, dbWriteTable, dbQuoteIdentifier,
     SQL
     postgresHasDefault.Rd: dbConnect
     postgresIsTransacting.Rd: dbBegin
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.
- [ ] WARN: r-devel-linux-x86_64-fedora-clang
     Found the following significant warnings:
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/R.hpp:52:31: warning: identifier '_xl' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/named_arg.hpp:42:29: warning: identifier '_nm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     See ‘/data/gannet/ripley/R/packages/tests-clang/RPostgres.Rcheck/00install.out’ for details.
     * used C compiler: ‘clang version 20.1.0-rc2’
     * used C++ compiler: ‘clang version 20.1.0-rc2’
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RPostgres.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RPostgres.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`