### PR TITLE
fledge: CRAN release v1.4.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RPostgres
 Title: C++ Interface to PostgreSQL
-Version: 1.4.7.9900
+Version: 1.4.8
 Date: 2025-02-24
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RPostgres 1.4.7.9900 (2025-02-24)
+# RPostgres 1.4.8 (2025-02-25)
 
 ## Windows
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,89 +4,11 @@
 
 ## Windows
 
-- Update libpq fallback library (#489).
-
-- Use libpq from Rtools if available (#486).
+- Use libpq from Rtools if available (#486), update libpq fallback library (#489).
 
 ## Features
 
-- Importing large objects from client side (@toppyy, #376, #472).
-
-## Chore
-
-- IDE.
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10425486593
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10224248168
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/10200112323
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/9728443553
-
-  Run: https://github.com/r-dbi/RPostgres/actions/runs/9692464325
-
-## Continuous integration
-
-- Test on older Windows versions.
-
-- Avoid failure in fledge workflow if no changes (#479).
-
-- Remove Aviator.
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#478).
-
-- Use stable pak (#477).
-
-- Latest changes (#475).
-
-- Import from actions-sync, check carefully (#474).
-
-- Use pkgdown branch (#473).
-
-  - ci: Use pkgdown branch
-
-  - ci: Updates from duckdb
-
-  - ci: Trigger run
-
-- Install via R CMD INSTALL ., not pak (#471).
-
-  - ci: Install via R CMD INSTALL ., not pak
-
-  - ci: Bump version of upload-artifact action
-
-- Install local package for pkgdown builds.
-
-- Improve support for protected branches with fledge.
-
-- Improve support for protected branches, without fledge.
-
-- Sync with latest developments.
-
-- Use v2 instead of master.
-
-- Inline action.
-
-- Use dev roxygen2 and decor.
-
-- Fix on Windows, tweak lock workflow.
-
-- Avoid checking bashisms on Windows.
-
-- Allow NOTEs on R-devel.
-
-- Better commit message.
-
-- Bump versions, better default, consume custom matrix.
-
-- Recent updates.
-
-## Uncategorized
-
-- Merge branch 'cran-1.4.7'.
+- New `postgresImportLargeObject()` for importing large objects from client side (@toppyy, #376, #472).
 
 
 # RPostgres 1.4.7 (2024-05-26)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RPostgres 1.4.7.9900
+RPostgres 1.4.8
 
 ## Cran Repository Policy
 

--- a/vignettes/work-queue.Rmd
+++ b/vignettes/work-queue.Rmd
@@ -124,7 +124,7 @@ One lucky worker will get a row back, but thanks to ``FOR UPDATE``, the row is n
 For any other worker, as the row is now locked, they will skip over it (``SKIP LOCKED``) and find something else to do.
 If there are no other jobs available, then nothing will be returned.
 
-Using SKIP LOCKED is discussed in more detail [in this article](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/).
+Using SKIP LOCKED is discussed in more detail [in this article](https://www.enterprisedb.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/).
 
 ```{r, echo = FALSE}
 if (!is.null(rs)) {


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-02-25, problems found: https://cran.r-project.org/web/checks/check_results_RPostgres.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     postgres-query.Rd: dbConnect, dbGetRowsAffected
     postgres-tables.Rd: dbAppendTable, dbWriteTable, dbQuoteIdentifier,
     SQL
     postgresHasDefault.Rd: dbConnect
     postgresIsTransacting.Rd: dbBegin
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.
- [ ] WARN: r-devel-linux-x86_64-fedora-clang
     Found the following significant warnings:
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/R.hpp:52:31: warning: identifier '_xl' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/named_arg.hpp:42:29: warning: identifier '_nm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     See ‘/data/gannet/ripley/R/packages/tests-clang/RPostgres.Rcheck/00install.out’ for details.
     * used C compiler: ‘clang version 20.1.0-rc2’
     * used C++ compiler: ‘clang version 20.1.0-rc2’
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RPostgres.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RPostgres.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`