### PR TITLE
docs: clarify schema discovery for dbListTables

### DIFF
--- a/R/dbConnect_PqDriver.R
+++ b/R/dbConnect_PqDriver.R
@@ -36,7 +36,10 @@
 #'   for details on this file and syntax.
 #' @param ... Other name-value pairs that describe additional connection
 #'   options as described at
-#'   <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS>
+#'   <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS>.
+#'   For example, set `options = "-c search_path=myschema"` to make
+#'   [dbListTables()] and unqualified reads and writes use `myschema`
+#'   by default for that connection.
 #' @param bigint The R type that 64-bit integer types should be mapped to,
 #'   default is [bit64::integer64], which allows the full range of 64 bit
 #'   integers.
@@ -50,11 +53,34 @@
 #'   set to [Sys.timezone()] or `""`.
 #'   This setting does not change the time values returned, only their display.
 #' @param conn Connection to disconnect.
+#' @section Additional connection options:
+#' Use `...` for libpq parameters that are not formal arguments to
+#' `dbConnect()`. Besides SSL settings, this can be useful for session options
+#' such as `search_path`:
+#'
+#' ```
+#' dbConnect(
+#'   RPostgres::Postgres(),
+#'   options = "-c search_path=analytics"
+#' )
+#' ```
+#'
 #' @rdname Postgres
 #' @examplesIf postgresHasDefault()
 #' library(DBI)
 #' # Pass more arguments as necessary to dbConnect()
 #' con <- dbConnect(RPostgres::Postgres())
+#'
+#' schema <- "rpostgres_example"
+#' dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", dbQuoteIdentifier(con, schema), " CASCADE"))
+#' dbExecute(con, paste0("CREATE SCHEMA ", dbQuoteIdentifier(con, schema)))
+#' dbWriteTable(con, Id(schema = schema, table = "schema_demo"), iris[1:3, ], overwrite = TRUE)
+#'
+#' con2 <- dbConnect(RPostgres::Postgres(), options = paste0("-c search_path=", schema))
+#' dbListTables(con2)
+#' dbDisconnect(con2)
+#'
+#' dbExecute(con, paste0("DROP SCHEMA ", dbQuoteIdentifier(con, schema), " CASCADE"))
 #' dbDisconnect(con)
 #' @usage NULL
 dbConnect_PqDriver <- function(

--- a/R/tables.R
+++ b/R/tables.R
@@ -10,6 +10,10 @@
 #' Pass an identifier created with [Id()] as the `name` argument
 #' to specify the schema or catalog, e.g.
 #' `name = Id(catalog = "my_catalog", schema = "my_schema", table = "my_table")` .
+#' To list objects in a specific schema without changing the connection
+#' defaults, use [dbListObjects()] with `Id(schema = "my_schema")`.
+#' To make [dbListTables()] use a schema by default for a connection, set
+#' `options = "-c search_path=my_schema"` in [dbConnect()].
 #' To specify the tablespace, use
 #' `dbExecute(conn, "SET default_tablespace TO my_tablespace")`
 #' before creating the table.
@@ -51,6 +55,19 @@
 #' # A zero row data frame just creates a table definition.
 #' dbWriteTable(con, "mtcars2", mtcars[0, ], temporary = TRUE)
 #' dbReadTable(con, "mtcars2")
+#'
+#' schema <- "rpostgres_example"
+#' dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", dbQuoteIdentifier(con, schema), " CASCADE"))
+#' dbExecute(con, paste0("CREATE SCHEMA ", dbQuoteIdentifier(con, schema)))
+#' dbWriteTable(con, Id(schema = schema, table = "schema_demo"), iris[1:3, ], overwrite = TRUE)
+#'
+#' dbListObjects(con, Id(schema = schema))
+#'
+#' con2 <- dbConnect(RPostgres::Postgres(), options = paste0("-c search_path=", schema))
+#' dbListTables(con2)
+#' dbDisconnect(con2)
+#'
+#' dbExecute(con, paste0("DROP SCHEMA ", dbQuoteIdentifier(con, schema), " CASCADE"))
 #'
 #' dbDisconnect(con)
 #' @name postgres-tables

--- a/man/Postgres.Rd
+++ b/man/Postgres.Rd
@@ -56,7 +56,10 @@ for details on this file and syntax.}
 
 \item{...}{Other name-value pairs that describe additional connection
 options as described at
-\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
+\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}.
+For example, set \code{options = "-c search_path=myschema"} to make
+\code{\link[DBI:dbListTables]{dbListTables()}} and unqualified reads and writes use \code{myschema}
+by default for that connection.}
 
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:integer64]{bit64::integer64}, which allows the full range of 64 bit
@@ -85,11 +88,35 @@ but still recommended;
 if you delete the object containing the connection, it will be automatically
 disconnected during the next GC with a warning.
 }
+\section{Additional connection options}{
+
+Use \code{...} for libpq parameters that are not formal arguments to
+\code{dbConnect()}. Besides SSL settings, this can be useful for session options
+such as \code{search_path}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{dbConnect(
+  RPostgres::Postgres(),
+  options = "-c search_path=analytics"
+)
+}\if{html}{\out{</div>}}
+}
+
 \examples{
 \dontshow{if (postgresHasDefault()) withAutoprint(\{ # examplesIf}
 library(DBI)
 # Pass more arguments as necessary to dbConnect()
 con <- dbConnect(RPostgres::Postgres())
+
+schema <- "rpostgres_example"
+dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", dbQuoteIdentifier(con, schema), " CASCADE"))
+dbExecute(con, paste0("CREATE SCHEMA ", dbQuoteIdentifier(con, schema)))
+dbWriteTable(con, Id(schema = schema, table = "schema_demo"), iris[1:3, ], overwrite = TRUE)
+
+con2 <- dbConnect(RPostgres::Postgres(), options = paste0("-c search_path=", schema))
+dbListTables(con2)
+dbDisconnect(con2)
+
+dbExecute(con, paste0("DROP SCHEMA ", dbQuoteIdentifier(con, schema), " CASCADE"))
 dbDisconnect(con)
 \dontshow{\}) # examplesIf}
 }

--- a/man/Redshift.Rd
+++ b/man/Redshift.Rd
@@ -53,7 +53,10 @@ for details on this file and syntax.}
 
 \item{...}{Other name-value pairs that describe additional connection
 options as described at
-\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}}
+\url{https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS}.
+For example, set \code{options = "-c search_path=myschema"} to make
+\code{\link[DBI:dbListTables]{dbListTables()}} and unqualified reads and writes use \code{myschema}
+by default for that connection.}
 
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:integer64]{bit64::integer64}, which allows the full range of 64 bit

--- a/man/postgres-tables.Rd
+++ b/man/postgres-tables.Rd
@@ -139,6 +139,10 @@ SQL string.
 Pass an identifier created with \code{\link[=Id]{Id()}} as the \code{name} argument
 to specify the schema or catalog, e.g.
 \code{name = Id(catalog = "my_catalog", schema = "my_schema", table = "my_table")} .
+To list objects in a specific schema without changing the connection
+defaults, use \code{\link[DBI:dbListObjects]{dbListObjects()}} with \code{Id(schema = "my_schema")}.
+To make \code{\link[DBI:dbListTables]{dbListTables()}} use a schema by default for a connection, set
+\code{options = "-c search_path=my_schema"} in \code{\link[DBI:dbConnect]{dbConnect()}}.
 To specify the tablespace, use
 \code{dbExecute(conn, "SET default_tablespace TO my_tablespace")}
 before creating the table.
@@ -158,6 +162,19 @@ dbExistsTable(con, "mtcars")
 # A zero row data frame just creates a table definition.
 dbWriteTable(con, "mtcars2", mtcars[0, ], temporary = TRUE)
 dbReadTable(con, "mtcars2")
+
+schema <- "rpostgres_example"
+dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", dbQuoteIdentifier(con, schema), " CASCADE"))
+dbExecute(con, paste0("CREATE SCHEMA ", dbQuoteIdentifier(con, schema)))
+dbWriteTable(con, Id(schema = schema, table = "schema_demo"), iris[1:3, ], overwrite = TRUE)
+
+dbListObjects(con, Id(schema = schema))
+
+con2 <- dbConnect(RPostgres::Postgres(), options = paste0("-c search_path=", schema))
+dbListTables(con2)
+dbDisconnect(con2)
+
+dbExecute(con, paste0("DROP SCHEMA ", dbQuoteIdentifier(con, schema), " CASCADE"))
 
 dbDisconnect(con)
 \dontshow{\}) # examplesIf}

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -66,7 +66,10 @@ test_that("search_path option exposes schema tables via dbListTables", {
       if (dbIsValid(con)) {
         quoted_schema <- as.character(dbQuoteIdentifier(con, schema))
         try(
-          dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", quoted_schema, " CASCADE")),
+          dbExecute(
+            con,
+            paste0("DROP SCHEMA IF EXISTS ", quoted_schema, " CASCADE")
+          ),
           silent = TRUE
         )
         dbDisconnect(con)

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -54,6 +54,50 @@ test_that("passing other options parameters", {
   expect_identical(r$application_name, "apple")
 })
 
+test_that("search_path option exposes schema tables via dbListTables", {
+  con <- postgresDefault()
+  con2 <- NULL
+  schema <- paste0("rpostgres_docs_", as.integer(Sys.getpid()))
+  on.exit(
+    {
+      if (!is.null(con2) && dbIsValid(con2)) {
+        dbDisconnect(con2)
+      }
+      if (dbIsValid(con)) {
+        quoted_schema <- as.character(dbQuoteIdentifier(con, schema))
+        try(
+          dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", quoted_schema, " CASCADE")),
+          silent = TRUE
+        )
+        dbDisconnect(con)
+      }
+    },
+    add = TRUE
+  )
+
+  quoted_schema <- as.character(dbQuoteIdentifier(con, schema))
+  dbExecute(con, paste0("DROP SCHEMA IF EXISTS ", quoted_schema, " CASCADE"))
+  dbExecute(con, paste0("CREATE SCHEMA ", quoted_schema))
+  table_name <- "schema_demo"
+  dbWriteTable(
+    con,
+    Id(schema = schema, table = table_name),
+    iris[1:3, ],
+    overwrite = TRUE
+  )
+
+  schema_tables <- dbListObjects(con, Id(schema = schema))
+  expect_equal(nrow(schema_tables), 1L)
+  expect_false(schema_tables$is_prefix[[1]])
+  expect_equal(
+    schema_tables$table[[1]],
+    Id(schema = schema, table = table_name)
+  )
+
+  con2 <- postgresDefault(options = paste0("-c search_path=", schema))
+  expect_equal(dbListTables(con2), table_name)
+})
+
 test_that("error if passing unkown parameters", {
   skip_on_cran()
   expect_error(


### PR DESCRIPTION
## Summary
Clarify how to discover tables in a non-default schema, both by listing objects with `Id(schema = ...)` and by using `options = "-c search_path=..."` for a connection.

## Thanks to maintainers
Thanks for the pointers in #399 and for the existing schema-qualified table examples.

## Issue or motivation
Issue #399 notes that users looking for tables in a specific schema do not easily find the supported workflows.

## Root cause
The connection docs only pointed readers to the general libpq options reference, and the table docs showed schema-qualified writes without showing the matching schema-scoped listing patterns.

## Change
- document `options = "-c search_path=..."` in the `dbConnect()` docs with a runnable example
- extend the table docs to show `dbListObjects(con, Id(schema = ...))` and `dbListTables()` on a connection with `search_path` set
- add a focused test covering the documented `search_path` workflow

## Tests
- `devtools::document()`
- `UserNM=true R CMD INSTALL .`
- `devtools::test(filter = "dbConnect")`
- `rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes"), error_on = "note")`
- `pkgdown::build_site(preview = FALSE)`

## Scope
I did not change `dbListTables()` behavior or add a new schema argument. This PR only documents the existing workflows and adds a focused regression test for the documented connection-option path.