### PR TITLE
fix: add `cleanup` script for R-devel check NOTEs and fix Docker cache import

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,7 +20,6 @@
 ^\.vscode$
 ^\.deps$
 ^autobrew$
-^cleanup$
 ^CRAN-SUBMISSION$
 ^\.gitpod\.yml$
 ^\.gitpod\.Dockerfile$

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@fdf7f43ecf7c1a5c7afe936410233728a8c2d9c2
         with:
           context: .
-          cache-from: ${{ ( github.event_name != 'schedule' || github.event_name != 'workflow_dispatch' ) && 'type=gha' || '' }}
+          cache-from: ${{ ( github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' ) && 'type=gha' || '' }}
           cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ tests/testthat/testthat-problems.rds
 configure.log
 .deps/
 autobrew
-cleanup
 .vscode
 .Renviron
 CRAN-SUBMISSION

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     covr,
     DBItest (>= 1.7.3),
     knitr,
+    purrr,
     rlang,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Suggests:
     covr,
     DBItest (>= 1.7.3),
     knitr,
-    purrr,
     rlang,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -f src/Makevars configure.log


### PR DESCRIPTION
## Summary

Two independent CI fixes on `main`. (The `rcc dev` dev-package install issue this branch originally also touched is now handled upstream by the Resolute migration + DBItest dropping `purrr`, so that workflow change was dropped when rebasing onto current `main`.)

### 1. `rcc` (R-devel job) — add a `cleanup` script
`configure` writes `configure.log` at the top level and generates `src/Makevars` from `src/Makevars.in`. On R-devel, `R CMD check` flags these as two NOTEs (`Non-standard file … 'configure.log'`; `Package has both 'src/Makevars.in' and 'src/Makevars'`), and the check runs with `error-on: "note"`, so the job fails. Added an executable `cleanup` script (`rm -f src/Makevars configure.log`, byte-identical to RMariaDB's) and stopped ignoring it in `.Rbuildignore`/`.gitignore` so it ships in the tarball and runs during check.

### 2. `Create and publish a Docker image` — fix the GHA cache import
`cache-from` used `||` where `&&` was intended (`event != 'schedule' || event != 'workflow_dispatch'` is always true), so every build imported `type=gha`; the nightly scheduled build then repeatedly failed with `RESPONSE 404 BlobNotFound` (the cache manifest referenced an evicted blob). Changed to `&&` so scheduled/manual builds skip the cache import and build fresh, while push builds still use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7