### PR TITLE
ci: Install `tzdata-legacy` on Ubuntu 26.04

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -5,6 +5,11 @@ runs:
   steps:
     # Must happen after installing system dependencies,
     # https://github.com/ankane/setup-mariadb/issues/2
+    #
+    # Postgres 17 is the one version ankane/setup-postgres offers on every
+    # runner image in the matrix: ubuntu-26.04 (where 18 is the default) and
+    # ubuntu-26.04-arm support 14-18, but windows-latest (windows-2025)
+    # supports 17 only.
     - uses: ankane/setup-postgres@v1
       with:
         postgres-version: ${{ matrix.pg-version || 17 }}

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -7,3 +7,16 @@ runs:
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
+
+    - name: Install legacy time zone data (Linux)
+      # Ubuntu 26.04 no longer ships the backward-compatibility zone names
+      # (PST8PDT, EST5EDT, US/Pacific, ...) in `tzdata`;
+      # they moved to the separate `tzdata-legacy` package.
+      # DBItest exercises PST8PDT,
+      # and without the package `lubridate::with_tz()` warns
+      # "Unrecognized time zone", which fails the round-trip timestamp tests.
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y tzdata-legacy
+      shell: bash


### PR DESCRIPTION
The `rcc` smoke test on `ubuntu-26.04` fails with 5 test failures, all of the same shape:

```
── Failure ('test-DBItest.R:6:5'): DBItest[RPostgres]: SQL: roundtrip_timestamp ──
Expected `eval(test_fun_expr)` not to throw any warnings.
Actually got a <simpleWarning> with message:
  Unrecognized time zone 'PST8PDT'
[ FAIL 5 | WARN 15 | SKIP 71 | PASS 8513 ]
```

Ubuntu 26.04 no longer ships the backward-compatibility zone names (`PST8PDT`, `EST5EDT`, `US/Pacific`, …) in `tzdata`; they moved to the separate `tzdata-legacy` package. Verified against the `resolute` archive: `PST8PDT` is present in `tzdata-legacy_2026b-0ubuntu0.26.04.1_all.deb` and absent from `tzdata_2026b-0ubuntu0.26.04.1_all.deb`. On `ubuntu-24.04` the plain `tzdata` still carried it, which is why this only surfaced after the runner bump.

`custom/before-install` now installs `tzdata-legacy` on Linux.

Also documents why `postgres-version` stays pinned to 17: `ubuntu-26.04` supports 14–18 (18 is its default), but `windows-latest` (windows-2025) supports 17 only, so 17 is the one version available across the whole matrix.

The same `tzdata-legacy` change is part of r-dbi/RMariaDB#548, which additionally adapts the MariaDB/MySQL setup to Ubuntu 26.04.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WN7DfEDqHx2pWJ9Z9neUTi)_